### PR TITLE
Update counties regions list

### DIFF
--- a/cost_service.py
+++ b/cost_service.py
@@ -17,6 +17,7 @@ import step13_combine_total_annual_costs as CombineTotalAnnualCosts
 import step14_build_capital_costs_lifetimes_incentives as BuildCapitalCostsLifetimesIncentives
 import step15_payback_periods as PaybackPeriods
 import step16_display_key_metrics_maps as DisplayKeyMetricsMaps
+from main_helpers import norcal_counties, socal_counties, central_counties
 
 class CostService:
 
@@ -112,11 +113,9 @@ Example usage:
 
 
 if __name__ == '__main__':
-    # Parse command-line arguments
     args = parse_arguments()
     scenario = args.scenario
     
-    # Validate scenario
     if scenario not in SCENARIOS:
         print(f"Error: Unknown scenario '{scenario}'")
         print(f"Available scenarios: {', '.join(SCENARIOS.keys())}")
@@ -125,29 +124,6 @@ if __name__ == '__main__':
     housing_type = "single-family-detached"
     input_dir = "data"
     output_dir = "data/loadprofiles"
-
-    norcal_counties = [
-        "Alameda County", "Contra Costa County", "Marin County", "Napa County", 
-        "San Francisco County", "San Mateo County", "Santa Clara County", "Solano County", "Sonoma County",  # Bay Area
-        "Del Norte County", "Humboldt County", "Lake County", "Mendocino County", "Trinity County",  # North Coast
-        "Butte County", "Colusa County", 
-        "Nevada County", "Plumas County", "Shasta County", "Sierra County", "Tehama County",  # North Valley & Sierra
-    ] # "Modoc County", "Glenn County", "Siskiyou County", "Lassen County"
-
-    central_counties = [
-        "Fresno County", "Kern County", "Kings County", "Madera County", "Merced County", 
-        "Sacramento County", "San Joaquin County", "Stanislaus County", "Sutter County", 
-        "Tulare County", "Yolo County",  # Central Valley
-        "Monterey County", "San Benito County", "San Luis Obispo County", "Santa Barbara County", 
-        "Santa Cruz County", "Ventura County",  # Central Coast
-        "Alpine County", "Amador County", "Mono County",  # Eastern Sierra & Inland
-    ]
-
-    socal_counties = [
-        "Los Angeles County", "Orange County", "San Bernardino County", 
-        "Riverside County", "Ventura County",  # Greater Los Angeles
-        "San Diego County", "Imperial County"  # San Diego & Imperial
-    ]
     
     rate_plans = {
             "PG&E": {

--- a/main_helpers.py
+++ b/main_helpers.py
@@ -8,6 +8,7 @@ LOADPROFILES = "loadprofiles" # folder name where all load profiles are stored
 norcal_counties = [
     "Alameda County", "Contra Costa County", "Marin County", "Napa County", 
     "San Francisco County", "San Mateo County", "Santa Clara County", "Solano County", "Sonoma County",  # Bay Area
+    "Sacramento County",
     "Del Norte County", "Humboldt County", "Lake County", "Mendocino County", "Trinity County",  # North Coast
     "Butte County", "Colusa County", # "Glenn County", "Lassen County", "Modoc County", 
     "Nevada County", "Plumas County", "Shasta County", "Sierra County", "Tehama County",  # "Siskiyou County", # North Valley & Sierra
@@ -16,15 +17,16 @@ norcal_counties = [
 
 central_counties = [
     "Fresno County", "Kern County", "Kings County", "Madera County", "Merced County", 
-    "Sacramento County", "San Joaquin County", "Stanislaus County", "Sutter County", 
+    "San Joaquin County", "Stanislaus County", "Sutter County", 
     "Tulare County", "Yolo County",  # Central Valley
-    "Monterey County", "San Benito County", "San Luis Obispo County", "Santa Barbara County", 
-    "Santa Cruz County", "Ventura County",  # Central Coast
+    "Monterey County", "San Benito County", "San Luis Obispo County", 
+    "Santa Cruz County",
     "Alpine County", "Amador County", "Mono County",  # Eastern Sierra & Inland
 ]
 
 socal_counties = [
     "Los Angeles County", "Orange County", "San Bernardino County", 
+    "Santa Barbara County", "Kern County",
     "Riverside County", "Ventura County",  # Greater Los Angeles
     "San Diego County", "Imperial County"  # San Diego & Imperial
 ]


### PR DESCRIPTION
ventura county was being counted twice. deduplicate from lists and reorganize counties to better fit regional categories.