### PR TITLE
Shift NREL ResStock Loadprofiles EST -> PST

### DIFF
--- a/step3_build_electricity_load_profiles.py
+++ b/step3_build_electricity_load_profiles.py
@@ -53,7 +53,7 @@ def read_parquet_file(file_path, required_cols):
     if missing_cols:
         return None, f"Missing columns in {file_path}: {missing_cols}"
 
-    data["timestamp"] = pd.to_datetime(data["timestamp"])
+    data["timestamp"] = pd.to_datetime(data["timestamp"]).dt.tz_localize('US/Eastern').dt.tz_convert('US/Pacific').dt.tz_localize(None)
     return data[required_cols], None # Returns (data, error) tuple
 
 def read_building_profile(file_path, end_uses):
@@ -64,7 +64,7 @@ def read_building_profile(file_path, end_uses):
     data, error = read_parquet_file(file_path, ["timestamp"] + end_uses)
     if error:
         return None, error
-    data["timestamp"] = pd.to_datetime(data["timestamp"])
+    data["timestamp"] = pd.to_datetime(data["timestamp"]).dt.tz_localize('US/Eastern').dt.tz_convert('US/Pacific').dt.tz_localize(None)
     data = data.set_index("timestamp")
     return data[end_uses], None
 

--- a/step4_build_gas_load_profiles.py
+++ b/step4_build_gas_load_profiles.py
@@ -21,7 +21,7 @@ def process_building_data(data, end_uses):
     if 'timestamp' not in data.columns or not all(col in data.columns for col in end_uses):
         raise ValueError("Missing required columns: 'timestamp' and/or end_uses.")
 
-    data['timestamp'] = pd.to_datetime(data['timestamp'])
+    data['timestamp'] = pd.to_datetime(data['timestamp']).dt.tz_localize('US/Eastern').dt.tz_convert('US/Pacific').dt.tz_localize(None)
     hourly_data = data[['timestamp'] + end_uses].copy()
     # Sum it to a total
     hourly_data['load.gas.total.kwh'] = hourly_data[end_uses].sum(axis=1)

--- a/step8_get_weather_files.py
+++ b/step8_get_weather_files.py
@@ -86,7 +86,7 @@ def fetch_weather_data(latitude, longitude, county):
         "wkt": f"POINT({longitude} {latitude})",
         "names": "tmy",  # Requesting Typical Meteorological Year data.
         "interval": REQUEST_INTERVAL,
-        "utc": "true",
+        "utc": "false",
         "email": DEFAULT_EMAIL
     }
 

--- a/step8_get_weather_files.py
+++ b/step8_get_weather_files.py
@@ -86,7 +86,7 @@ def fetch_weather_data(latitude, longitude, county):
         "wkt": f"POINT({longitude} {latitude})",
         "names": "tmy",  # Requesting Typical Meteorological Year data.
         "interval": REQUEST_INTERVAL,
-        "utc": "false",
+        "utc": "true",
         "email": DEFAULT_EMAIL
     }
 

--- a/step9_run_sam_model_for_solar_storage.py
+++ b/step9_run_sam_model_for_solar_storage.py
@@ -16,7 +16,24 @@ SOLAR_STORAGE_CAPACITY_PREFIX = "electrified_assets"
 CAPITAL_COSTS_FOLDER_NAME = "CAPITAL_COSTS"
 
 def prepare_data_and_compute_system_capacity(weather_file, load_file, years_of_analysis):
+    # Load weather data in UTC from NREL API
     solar_resource_data = tools.SAM_CSV_to_solar_data(weather_file)
+    
+    # Convert weather data from UTC to Pacific Time to align with load profiles
+    # Note: SAM internally handles solar position calculations based on location,
+    # but we need temporal alignment between weather and load data
+    # Since both datasets are 8760 hourly values for the same year,
+    # we apply a 3-hour shift to convert from UTC to Pacific Standard Time
+    weather_arrays = ['dn', 'df', 'gh', 'tdry', 'tdew', 'rhum', 'wdir', 'wspd']
+    utc_to_pst_shift = 8  # Hours to shift UTC to PST (8 hours behind UTC)
+    
+    for array_name in weather_arrays:
+        if array_name in solar_resource_data:
+            # Shift array by 8 hours (UTC to PST)
+            original_array = solar_resource_data[array_name]
+            # Roll array to shift timezone: positive shift moves data earlier in time
+            solar_resource_data[array_name] = [original_array[(i + utc_to_pst_shift) % 8760] for i in range(8760)]
+    
     load_data = pd.read_csv(load_file)
     load_profile = load_data[TOTAL_LOAD_COLUMN_NAME].tolist()
     # TEMP CONSTANT LOAD
@@ -294,8 +311,7 @@ def validate_and_save_results(county, load_profile, system_to_load, batt_to_load
         'Battery SOC': battery_soc,
     }, index=date_range)
 
-    # TODO: Ana, I think the load profiles need to be shifted by 3 hours 
-    # They are provided in ET, we're working with PT
+    # Load profiles (converted from EST) and weather data (converted from UTC) are both aligned to Pacific Time
     log(
         at="step8_run_sam_model_for_solar_storage",
         load_profile=format_load_profile(load_profile),


### PR DESCRIPTION
NREL ResStock Loadprofiles are in eastern time out-of-the-box. This documentation shows it: https://oedi-data-lake.s3.amazonaws.com/nrel-pds-building-stock/end-use-load-profiles-for-us-building-stock/README.md (ctrl-f "timestamp" or "EST"). 

This PR shifts gas and electricity timestamps to PST: 

  1. Primary fix: step3_build_electricity_load_profiles.py:56,67 - Where ResStock electricity data is
   first processed with pd.to_datetime(data["timestamp"])
  2. Secondary fix: step4_build_gas_load_profiles.py:24 - Where gas load data timestamps are
  processed

These are the earliest points where ResStock data enters the pipeline. All downstream processing (steps 6, 9, 11) relies on these converted timestamps. 

For later: step7_get_weather_files.py:89 fetches weather data in UTC, so may also need timezone
  alignment between weather and load data in step8_run_sam_model_for_solar_storage.py