### PR TITLE
Streamline paper claims

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           python-version: "3.10"
       - run: python -m pip install --upgrade pip
-      - run: pip install pytest pytest-html pandas pulp numpy matplotlib requests geopandas folium boto3 python-dotenv
+      - run: pip install pytest pytest-html pandas pulp numpy matplotlib requests geopandas geopy folium boto3 python-dotenv
       - run: pytest -q tests/ --html=test_report.html --self-contained-html

--- a/evaluations/__init__.py
+++ b/evaluations/__init__.py
@@ -26,6 +26,7 @@ from .lcoe import (
     lcoe_npv_from_params,
     lcoe_from_schedules,
 )
+from .sensitivity import SensitivityParameter, SENSITIVITY_PARAMETERS
 
 __all__ = [
     "npv",
@@ -39,4 +40,6 @@ __all__ = [
     "lcoe_crf_simple",
     "lcoe_npv_from_params",
     "lcoe_from_schedules",
+    "SensitivityParameter",
+    "SENSITIVITY_PARAMETERS",
 ]

--- a/evaluations/constants.py
+++ b/evaluations/constants.py
@@ -8,3 +8,8 @@ LIFETIMES_DEFAULT = {
 
 THERM_TO_KWH = 29.3001
 
+# Real discount rate used to annualize capex throughout the pipeline (CRF, NPV,
+# LCOE). Defined once here so a rate change or sensitivity sweep is a single
+# edit instead of a repo-wide find-and-replace across ~25 default arguments.
+DEFAULT_DISCOUNT_RATE = 0.07
+

--- a/evaluations/eac.py
+++ b/evaluations/eac.py
@@ -5,6 +5,8 @@ from typing import Mapping, Optional
 
 import pandas as pd
 
+from .constants import DEFAULT_DISCOUNT_RATE
+
 
 def crf(rate: float, years: float) -> float:
     """Capital Recovery Factor.
@@ -79,7 +81,7 @@ def compute_eac_from_inputs(
     pv_summary_row: Optional[pd.Series | Mapping[str, float]],
     *,
     incentive: str = "full_incentives",
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     lifetimes: Optional[Mapping[str, float]] = None,
     annual_bill_electric: float = 0.0,
     annual_bill_gas: float = 0.0,

--- a/evaluations/npv.py
+++ b/evaluations/npv.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Iterable
 
+from .constants import DEFAULT_DISCOUNT_RATE
+
 
 def annuity_factor(rate: float, n_years: float) -> float:
     """Return annuity factor A such that EAC = NPV * A.
@@ -40,7 +42,7 @@ def compute_npv_details_from_inputs(
     pv_storage_net_capex: float,
     electrification_net_capex: float | None,
     horizon_years: int = 25,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
 ) -> dict:
     """Compute NPV details from numeric inputs (no I/O).
 

--- a/evaluations/sensitivity.py
+++ b/evaluations/sensitivity.py
@@ -1,0 +1,54 @@
+"""Sensitivity parameter registry — pure, no I/O.
+
+States which pipeline stages each parameter actually requires re-running.
+This is where a real methodology question gets answered on purpose instead
+of by accident: NBC currently affects only billing (step 12), not the LP's
+price series in step 9b — so an NBC sweep does not need to re-solve the LP.
+If that assumption should ever change (NBC should feed the LP's dispatch
+signal), the fix is to flip `requires_lp_resolve` here, deliberately, not to
+discover the gap later.
+
+The orchestration that actually runs a sweep (calls the pipeline modules,
+writes results) lives in `pipeline.sensitivity_runner`, which imports this
+registry — kept separate so this module stays consistent with the rest of
+evaluations/ (side-effect-free, safe to import and reason about anywhere).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class SensitivityParameter:
+    name: str
+    config_field: str
+    requires_lp_resolve: bool
+    description: str
+
+
+SENSITIVITY_PARAMETERS: Dict[str, SensitivityParameter] = {
+    "discount_rate": SensitivityParameter(
+        name="discount_rate",
+        config_field="discount_rate",
+        requires_lp_resolve=True,
+        description=(
+            "Real discount rate used for CRF/NPV annualization. Changes the "
+            "LP's optimal PV/battery sizing (step 9b), not just EAC "
+            "annualization at report time — a full resolve is required."
+        ),
+    ),
+    "nbc_dollars_per_kwh": SensitivityParameter(
+        name="nbc_dollars_per_kwh",
+        config_field="nbc_dollars_per_kwh_override",
+        requires_lp_resolve=False,
+        description=(
+            "Non-bypassable charge applied to electricity imports. Currently "
+            "affects only billing (step 12), not the LP's price series in "
+            "step 9b — the LP sizes PV/battery as if NBC were always 0. No "
+            "resolve needed; only steps 10-14 (rates/capital) re-run. If NBC "
+            "should ever feed the LP's dispatch signal, flip "
+            "requires_lp_resolve to True here — deliberately, not by accident."
+        ),
+    ),
+}

--- a/experiments/battery_size_sweep.py
+++ b/experiments/battery_size_sweep.py
@@ -34,11 +34,13 @@ from appliances.battery_storage import BatteryStorageAppliance
 from appliances.electric_base import IncentiveScenario
 from step15_payback_periods import vehicle_annual_adders_from_ledger
 from evaluations.eac import crf as _crf
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 
 @dataclass
 class BatterySweepOptions:
     compute_bills: bool = False
+    discount_rate: float = DEFAULT_DISCOUNT_RATE
 
 
 def _paths_for_county(base_input_dir: str, scenario: str, housing_type: str, county: str) -> Dict[str, str]:
@@ -105,7 +107,7 @@ def _eac_baseline_components(
     ledger: Optional[pd.DataFrame],
     scenario: str,
     county_slug: str,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
 ) -> Dict[str, float]:
     capex_electric = 0.0
     capex_gas = 0.0
@@ -332,7 +334,7 @@ def run_for_county(
         system_kw = float(base_kw) * float(getattr(diy, 'PV_SIZE_FRACTION', 1.0))
 
     ledger = _read_capital_ledger(base_input_dir, scenario, housing_type)
-    base_eac = _eac_baseline_components(ledger, scenario, county_slug)
+    base_eac = _eac_baseline_components(ledger, scenario, county_slug, discount_rate=options.discount_rate)
     exp_county_dir = os.path.join(experiments_root, scenario, housing_type, county_slug)
     _ensure_dir(exp_county_dir)
 
@@ -345,7 +347,7 @@ def run_for_county(
             pv_capex_base = float(sub.iloc[0].get('pv_capex', 0.0) or 0.0)
             pv_inc_full = float(sub.iloc[0].get('pv_incentives_full', 0.0) or 0.0)
             pv_net = pv_capex_base - pv_inc_full
-    crf_pv = _crf(0.07, LIFETIMES.get('solar', 25))
+    crf_pv = _crf(options.discount_rate, LIFETIMES.get('solar', 25))
 
     rows: List[Dict] = []
     for cap_kwh in capacities_kwh:
@@ -362,7 +364,7 @@ def run_for_county(
 
         # Storage capex/net scaled linearly from BatteryStorageAppliance unit economics
         st = _battery_costs_for_kwh(cap_kwh)
-        crf_st = _crf(0.07, LIFETIMES.get('storage', 15))
+        crf_st = _crf(options.discount_rate, LIFETIMES.get('storage', 15))
         capex_storage_annual = st['storage_net'] * crf_st
         capex_pv_annual = pv_net * crf_pv
 

--- a/experiments/combined_sweep.py
+++ b/experiments/combined_sweep.py
@@ -31,11 +31,13 @@ from appliances.battery_storage import BatteryStorageAppliance
 from appliances.electric_base import IncentiveScenario
 from step15_payback_periods import vehicle_annual_adders_from_ledger
 from evaluations.eac import crf as _crf
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 
 @dataclass
 class CombinedSweepOptions:
     compute_bills: bool = False
+    discount_rate: float = DEFAULT_DISCOUNT_RATE
 
 
 def _paths_for_county(base_input_dir: str, scenario: str, housing_type: str, county: str) -> Dict[str, str]:
@@ -102,7 +104,7 @@ def _eac_baseline_components(
     ledger: Optional[pd.DataFrame],
     scenario: str,
     county_slug: str,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
 ) -> Dict[str, float]:
     capex_electric = 0.0
     capex_gas = 0.0
@@ -217,7 +219,7 @@ def run_for_county(
     base_kw = diy._compute_system_capacity_kW(weather_df, load_profile)  # type: ignore
 
     ledger = _read_capital_ledger(base_input_dir, scenario, housing_type)
-    base_eac = _eac_baseline_components(ledger, scenario, county_slug)
+    base_eac = _eac_baseline_components(ledger, scenario, county_slug, discount_rate=options.discount_rate)
     exp_county_dir = os.path.join(experiments_root, scenario, housing_type, county_slug)
     _ensure_dir(exp_county_dir)
 
@@ -230,8 +232,8 @@ def run_for_county(
             pv_row = sub.iloc[0]
     if pv_row is None:
         pv_row = pd.Series({'solar_kw': 0.0, 'pv_capex': 0.0, 'pv_incentives_full': 0.0})
-    crf_pv = _crf(0.07, LIFETIMES.get('solar', 25))
-    crf_st = _crf(0.07, LIFETIMES.get('storage', 15))
+    crf_pv = _crf(options.discount_rate, LIFETIMES.get('solar', 25))
+    crf_st = _crf(options.discount_rate, LIFETIMES.get('storage', 15))
 
     rows: List[Dict] = []
     for f in fractions:

--- a/experiments/solar_size_sweep.py
+++ b/experiments/solar_size_sweep.py
@@ -31,11 +31,13 @@ import step9_my_own_solar_storage as diy
 from helpers.capital_cost_map_builder import LIFETIMES
 from step15_payback_periods import vehicle_annual_adders_from_ledger
 from evaluations.eac import crf as _crf
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 
 @dataclass
 class SweepOptions:
     compute_bills: bool = False
+    discount_rate: float = DEFAULT_DISCOUNT_RATE
 
 
 def _paths_for_county(base_input_dir: str, scenario: str, housing_type: str, county: str) -> Dict[str, str]:
@@ -130,7 +132,7 @@ def _eac_baseline_components(
     ledger: Optional[pd.DataFrame],
     scenario: str,
     county_slug: str,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
 ) -> Dict[str, float]:
     """Compute annualized capex for 'electric' (ex PV/storage) and 'gas', and vehicle O&M from the ledger.
     Independent of PV size.
@@ -448,7 +450,7 @@ def run_for_county(
     rows: List[Dict] = []
     # Read ledger once per county to compute baseline components
     ledger = _read_capital_ledger(base_input_dir, scenario, housing_type)
-    base_eac = _eac_baseline_components(ledger, scenario, county_slug)
+    base_eac = _eac_baseline_components(ledger, scenario, county_slug, discount_rate=options.discount_rate)
     exp_county_dir = os.path.join(experiments_root, scenario, housing_type, county_slug)
     _ensure_dir(exp_county_dir)
 
@@ -508,8 +510,8 @@ def run_for_county(
         pvst_capex = pv_capex + st_capex
         pvst_net   = pv_net + st_net
         # Annualized PV & storage capex per fraction
-        crf_pv = _crf(0.07, LIFETIMES.get('solar', 25))
-        crf_st = _crf(0.07, LIFETIMES.get('storage', 15))
+        crf_pv = _crf(options.discount_rate, LIFETIMES.get('solar', 25))
+        crf_st = _crf(options.discount_rate, LIFETIMES.get('storage', 15))
         capex_pv_annual = pv_net * crf_pv
         capex_storage_annual = st_net * crf_st
 

--- a/helpers/main_helpers.py
+++ b/helpers/main_helpers.py
@@ -156,6 +156,44 @@ def format_load_profile(load_profile):
     return [round(x, 3) for x in load_profile[5:20]]
 
 
+def merge_and_write_csv(df: pd.DataFrame, path: str, key_col="county_slug") -> None:
+    """Write df to path, preserving existing rows whose key isn't in this run.
+
+    Several pipeline outputs (capital_costs ledgers in step14, cross-scenario
+    exports in step18) are single shared files covering every county (and, in
+    step18's case, every scenario) for a given output, but a single call site
+    often only computes a subset (e.g. a targeted re-run for 3 counties, or a
+    cross-scenario comparison over one scenario family). A plain `to_csv`
+    silently discards every row not in the current run — this happened for
+    real once (an Alameda row was lost extending a 1-county analysis to 3
+    more). Instead: drop any existing rows matching this run's keys (so
+    re-runs correctly refresh them), then union with rows this run didn't
+    touch.
+
+    key_col: a single column name, or a list of column names for a composite
+    key. Use a composite key (e.g. ["scenario", "county_slug"]) whenever a
+    single call can supply a partial slice along more than one dimension —
+    e.g. step18's by-county exports have one row per (scenario, county), so
+    keying on county_slug alone would wrongly drop other scenarios' rows for
+    a county that reappears in a later, differently-scoped run.
+
+    Note: this is safe for sequential runs only. Concurrent writers to the
+    same path can still race (read-modify-write, no locking).
+    """
+    key_cols = [key_col] if isinstance(key_col, str) else list(key_col)
+
+    if os.path.exists(path):
+        existing = pd.read_csv(path)
+        if all(k in existing.columns for k in key_cols) and all(k in df.columns for k in key_cols):
+            incoming_keys = set(map(tuple, df[key_cols].values.tolist()))
+            existing_keys = existing[key_cols].apply(tuple, axis=1)
+            existing = existing[~existing_keys.isin(incoming_keys)]
+            df = pd.concat([existing, df], ignore_index=True)
+    if all(k in df.columns for k in key_cols):
+        df = df.sort_values(key_cols)
+    df.to_csv(path, index=False)
+
+
 def log_step(step: int | str, label: str | None = None) -> None:
     """Print a simple step banner for progress visibility.
 

--- a/helpers/plot_scenario_comparison_helper.py
+++ b/helpers/plot_scenario_comparison_helper.py
@@ -60,6 +60,7 @@ from evaluations.vehicles import vehicle_annual_adders_from_ledger
 from evaluations.eac import crf as _crf, compute_eac_from_inputs
 from evaluations.tariffs import select_row_value_for_plan as _select_plan_value
 from evaluations.lcoe import lcoe_crf_simple
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 
 # ---------- Internal data access helpers ----------
@@ -860,7 +861,7 @@ def collect_pv_lcoe(
     housing_type: str,
     scenarios: Iterable[str],
     counties: Iterable[str],
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     lifetime_years: float = 25.0,
     agg: str = "mean",
 ) -> pd.DataFrame:
@@ -909,7 +910,7 @@ def collect_pv_lcoe_by_county(
     housing_type: str,
     scenarios: Iterable[str],
     counties: Iterable[str],
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     lifetime_years: float = 25.0,
 ) -> pd.DataFrame:
     """Collect PV LCOE ($/kWh) per county for each scenario.
@@ -994,7 +995,7 @@ def collect_eac_components(
     scenarios: Iterable[str],
     counties: Iterable[str],
     incentive: str = "full_incentives",
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     agg: str = "mean",
     timestamp: Optional[str] = None,
     electricity_plan_preference: Optional[Iterable[str]] = None,
@@ -1131,7 +1132,7 @@ def collect_eac_components_by_county(
     scenarios: Iterable[str],
     counties: Iterable[str],
     incentive: str = "full_incentives",
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     timestamp: Optional[str] = None,
     electricity_plan_preference: Optional[Iterable[str]] = None,
     electricity_variant: Optional[str] = "nem3",

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
+
 
 @dataclass
 class Config:
@@ -24,6 +26,10 @@ class Config:
     rate_plans: Optional[Dict[str, Dict[str, str]]] = None
     electricity_variant: str = "nem3"
     incentive: str = "full_incentives"
-    discount_rate: float = 0.07
+    discount_rate: float = DEFAULT_DISCOUNT_RATE
     agg: str = "mean"
+
+    # Sensitivity override: non-bypassable charge ($/kWh). None = use each
+    # utility's default (currently 0.0 for all three — see helpers/nem3_export_rates.py).
+    nbc_dollars_per_kwh_override: Optional[float] = None
 

--- a/pipeline/modules/rates_capital/__init__.py
+++ b/pipeline/modules/rates_capital/__init__.py
@@ -27,7 +27,10 @@ def run(cfg: Config) -> None:
 
     # 12) Electricity rates
     log_step(12)
-    EvaluateElectricityRates.process(base_dir, base_dir, cfg.scenario, cfg.housing_type, c_list)
+    EvaluateElectricityRates.process(
+        base_dir, base_dir, cfg.scenario, cfg.housing_type, c_list,
+        nbc_dollars_per_kwh_override=cfg.nbc_dollars_per_kwh_override,
+    )
 
     # 13) Combine totals
     log_step(13)

--- a/pipeline/modules/solar_storage/__init__.py
+++ b/pipeline/modules/solar_storage/__init__.py
@@ -50,6 +50,7 @@ def run(cfg: Config) -> None:
             counties=c_list,
             allow_grid_charging=False,
             allow_batt_export=True,
+            discount_rate=cfg.discount_rate,
         )
     else:
         Step9MyOwnSolarStorage.process(

--- a/pipeline/modules/visualization/__init__.py
+++ b/pipeline/modules/visualization/__init__.py
@@ -1,4 +1,4 @@
-git adfrom __future__ import annotations
+from __future__ import annotations
 
 import os
 from typing import Dict, Iterable, List, Optional

--- a/pipeline/modules/visualization/__init__.py
+++ b/pipeline/modules/visualization/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+git adfrom __future__ import annotations
 
 import os
 from typing import Dict, Iterable, List, Optional
@@ -108,6 +108,7 @@ def run(cfg: Config) -> None:
             c_list,
             plan_preference=plan_preference,
             electricity_variant=cfg.electricity_variant,
+            discount_rate=cfg.discount_rate,
         )
     except Exception as e:
         print(f"[Step18] Skipped (missing sibling scenario data): {e}")

--- a/pipeline/sensitivity_runner.py
+++ b/pipeline/sensitivity_runner.py
@@ -1,0 +1,126 @@
+"""Sensitivity sweep orchestration.
+
+Before this existed, "sensitivity analysis" meant manually overriding a
+Config field, manually deciding which pipeline steps needed to re-run, and
+manually assembling a comparison table — the exact ad hoc pattern that
+produced the bugs fixed earlier tonight (LP silently duplicating a
+primitive, discount_rate never reaching the LP or the reporting layer, NBC
+having no override path at all).
+
+`run_sensitivity` re-runs only the stages `evaluations.sensitivity`'s
+registry says are necessary for a given parameter, using the same Config
+threading fixed tonight, and writes one tidy schema (parameter, value,
+scenario, county_slug, EAC components) through the shared
+`merge_and_write_csv` helper — keyed on all four of those columns, so
+sweeping one parameter can't collide with another parameter's sweep, another
+scenario's rows, or the point-estimate ledger, and re-running one value only
+refreshes that value's rows. The output file uses a stable name (no git-sha
+suffix) since the merge semantics make "which file is current" unambiguous
+by construction.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from pipeline.config import Config
+from pipeline.modules import solar_storage as mod_solar_storage
+from pipeline.modules import rates_capital as mod_rates_capital
+from helpers.main_helpers import merge_and_write_csv
+from helpers.plot_scenario_comparison_helper import collect_eac_components_by_county
+from evaluations.sensitivity import SENSITIVITY_PARAMETERS
+
+DEFAULT_RATE_PLANS: Dict[str, Dict[str, str]] = {
+    "PG&E": {"electricity": "E-TOU-D", "gas": "G-1"},
+    "SCE": {"electricity": "TOU-D-4-9PM", "gas": "GR"},
+    "SDG&E": {"electricity": "TOU-DR1", "gas": "GR"},
+}
+
+
+def _plan_preference_from(rate_plans: Optional[Dict[str, Dict[str, str]]]) -> Optional[List[str]]:
+    if not rate_plans:
+        return None
+    return list({
+        v.get("electricity") for v in rate_plans.values()
+        if isinstance(v, dict) and v.get("electricity")
+    })
+
+
+def run_sensitivity(
+    parameter_name: str,
+    values: Iterable[float],
+    *,
+    scenario: str,
+    sibling_scenarios: List[str],
+    counties: List[str],
+    housing_type: str = "single-family-detached",
+    base_input_dir: str = "data/loadprofiles",
+    output_dir: str = "analysis_results",
+    rate_plans: Optional[Dict[str, Dict[str, str]]] = None,
+    electricity_variant: str = "nem3",
+    incentive: str = "full_incentives",
+) -> pd.DataFrame:
+    """Run a one-parameter sensitivity sweep; return the tidy result DataFrame.
+
+    For each value: builds a Config with that value substituted for the swept
+    parameter, re-runs only the pipeline stages SENSITIVITY_PARAMETERS says
+    are necessary, and collects EAC-by-county results tagged with
+    (parameter, value). `sibling_scenarios` should include `scenario` itself
+    plus whatever comparison scenarios the resulting table needs (e.g. for
+    the Claims 3&4 comparison: ["baseline_ice_car", "full_electric_ev",
+    "full_electric_ev_coopt"]).
+    """
+    if parameter_name not in SENSITIVITY_PARAMETERS:
+        raise ValueError(
+            f"Unknown sensitivity parameter '{parameter_name}'. "
+            f"Known: {sorted(SENSITIVITY_PARAMETERS)}. "
+            "Add it to SENSITIVITY_PARAMETERS first (evaluations/sensitivity.py) "
+            "— including which pipeline stages it actually requires re-running."
+        )
+    param = SENSITIVITY_PARAMETERS[parameter_name]
+    rate_plans = rate_plans or DEFAULT_RATE_PLANS
+    plan_preference = _plan_preference_from(rate_plans)
+
+    all_rows = []
+    for value in values:
+        cfg = Config(
+            scenario=scenario,
+            housing_type=housing_type,
+            counties=counties,
+            base_input_dir=base_input_dir,
+            output_dir=output_dir,
+            rate_plans=rate_plans,
+            electricity_variant=electricity_variant,
+            incentive=incentive,
+        )
+        cfg = replace(cfg, **{param.config_field: value})
+
+        if param.requires_lp_resolve:
+            mod_solar_storage.run(cfg)
+        mod_rates_capital.run(cfg)
+
+        by_cty = collect_eac_components_by_county(
+            cfg.base_input_dir,
+            cfg.housing_type,
+            sibling_scenarios,
+            cfg.counties,
+            incentive=cfg.incentive,
+            discount_rate=cfg.discount_rate,
+            electricity_plan_preference=plan_preference,
+            electricity_variant=cfg.electricity_variant,
+        )
+        by_cty["parameter"] = parameter_name
+        by_cty["value"] = value
+        all_rows.append(by_cty)
+
+    combined = pd.concat(all_rows, ignore_index=True)
+    comp_cols = [c for c in ["capex_pv", "capex_storage", "capex_electric", "capex_gas", "vehicle_om"] if c in combined.columns]
+    bill_cols = [c for c in ["annual_bill_electric", "annual_bill_gas"] if c in combined.columns]
+    combined["total_eac"] = combined[comp_cols].sum(axis=1) + combined[bill_cols].sum(axis=1)
+
+    out_path = os.path.join(output_dir, f"sensitivity_{parameter_name}.csv")
+    merge_and_write_csv(combined, out_path, key_col=["parameter", "value", "scenario", "county_slug"])
+    return combined

--- a/pipeline/steps/step12_evaluate_electricity_rates.py
+++ b/pipeline/steps/step12_evaluate_electricity_rates.py
@@ -10,6 +10,7 @@
 
 from datetime import datetime, timedelta
 import argparse
+import dataclasses
 import os
 import pandas as pd
 from collections import defaultdict
@@ -272,7 +273,7 @@ def process_county_scenario_from_series(file_path, county, utility, selected_rat
     return calculate_annual_costs_electricity(load_profile, utility, selected_rate_plan, timestamps=timestamps)
 
 
-def process_county_scenario_nem3(file_path, county, utility, selected_rate_plan):
+def process_county_scenario_nem3(file_path, county, utility, selected_rate_plan, *, nbc_dollars_per_kwh_override=None):
     """Compute NEM3 bill using Aggregator columns: nem3.imports.kwh and nem3.exports.kwh."""
     file = os.path.join(file_path, county, f"{INPUT_FILE_NAME}_{county}.csv")
     if not os.path.exists(file):
@@ -285,6 +286,8 @@ def process_county_scenario_nem3(file_path, county, utility, selected_rate_plan)
     exports_col = "nem3.exports.kwh"
 
     opts = default_options_for_utility(utility)
+    if nbc_dollars_per_kwh_override is not None:
+        opts = dataclasses.replace(opts, nbc_dollars_per_kwh=nbc_dollars_per_kwh_override)
     base_dir = os.path.join("data", "NEM3")
     export_table = get_export_rate_table_for_county(base_dir=base_dir, utility=utility, county_name_or_slug=county)
 
@@ -380,7 +383,7 @@ def utility_to_rate_plans(utility: str):
         case _:
             raise ValueError(f"Unknown utility: {utility}")
     
-def process(base_input_dir, base_output_dir, scenario, housing_type, counties, use_nem3: bool = False):
+def process(base_input_dir, base_output_dir, scenario, housing_type, counties, use_nem3: bool = False, *, nbc_dollars_per_kwh_override=None):
     timestamp = get_timestamp()
 
     scenario_path = get_scenario_path(base_input_dir, scenario, housing_type)
@@ -403,7 +406,10 @@ def process(base_input_dir, base_output_dir, scenario, housing_type, counties, u
             )
 
             # NEM3 overlay for solarstorage (exports credited at ACC, NBCs applied)
-            solar_nem3 = process_county_scenario_nem3(scenario_path, county, utility, rate_plan)
+            solar_nem3 = process_county_scenario_nem3(
+                scenario_path, county, utility, rate_plan,
+                nbc_dollars_per_kwh_override=nbc_dollars_per_kwh_override,
+            )
 
             annual_costs_results = build_results_df_with_variants(
                 scenario,

--- a/pipeline/steps/step14_build_capital_costs_lifetimes_incentives.py
+++ b/pipeline/steps/step14_build_capital_costs_lifetimes_incentives.py
@@ -8,7 +8,7 @@ a lifetime, and associated incentives at the state, federal, and utility level.
 
 import os
 import pandas as pd
-from helpers.main_helpers import log, slugify_county_name, get_scenario_path, norcal_counties, socal_counties, central_counties
+from helpers.main_helpers import log, slugify_county_name, get_scenario_path, norcal_counties, socal_counties, central_counties, merge_and_write_csv
 from helpers.capital_costs_helper import load_electrified_assets
 from scenarios import SCENARIOS
 from typing import Dict, Tuple
@@ -658,16 +658,19 @@ def process(
     os.makedirs(out_dir, exist_ok=True)
 
     detailed_name = f"capital_costs_{scenario}_{housing_type.replace('-', '_')}.csv"
-    ledger_df.to_csv(os.path.join(out_dir, detailed_name), index=False)
-    print(os.path.join(out_dir, detailed_name))
+    detailed_path = os.path.join(out_dir, detailed_name)
+    merge_and_write_csv(ledger_df, detailed_path)
+    print(detailed_path)
 
     summary_name = f"capital_costs_summary_{scenario}_{housing_type.replace('-', '_')}.csv"
-    summary.to_csv(os.path.join(out_dir, summary_name), index=False)
-    print(os.path.join(out_dir, summary_name))
+    summary_path = os.path.join(out_dir, summary_name)
+    merge_and_write_csv(summary, summary_path)
+    print(summary_path)
 
     summary_pv_name = f"capital_costs_summary_with_pv_{scenario}_{housing_type.replace('-', '_')}.csv"
-    summary_with_pv.to_csv(os.path.join(out_dir, summary_pv_name), index=False)
-    print(os.path.join(out_dir, summary_pv_name))
+    summary_pv_path = os.path.join(out_dir, summary_pv_name)
+    merge_and_write_csv(summary_with_pv, summary_pv_path)
+    print(summary_pv_path)
 
     log(
         at="process", 

--- a/pipeline/steps/step18_cross_scenario_comparisons.py
+++ b/pipeline/steps/step18_cross_scenario_comparisons.py
@@ -28,7 +28,7 @@ from typing import List, Set
 
 import pandas as pd
 
-from helpers.main_helpers import git_short_sha
+from helpers.main_helpers import git_short_sha, merge_and_write_csv
 from helpers.plot_scenario_comparison_helper import (
     collect_payback_with_solar,
     plot_payback_dotline,
@@ -43,6 +43,7 @@ from helpers.plot_scenario_comparison_helper import (
     collect_pv_lcoe,
     collect_pv_lcoe_by_county,
 )
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 from helpers.main_helpers import get_scenario_path
 from scenarios import SCENARIOS
@@ -201,6 +202,7 @@ def process(
     electricity_variant: str = "nem3",
     agg: str = "mean",
     run_timestamp: str | None = None,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
 ):
     os.makedirs(output_dir, exist_ok=True)
     sha = git_short_sha()
@@ -212,6 +214,7 @@ def process(
         scenarios,
         counties,
         incentive='full_incentives',
+        discount_rate=discount_rate,
         agg=agg,
         timestamp=run_timestamp,
         electricity_plan_preference=plan_preference,
@@ -225,7 +228,7 @@ def process(
             bill_col = eac_df.get('annual_bill_with_solar', pd.Series([0] * len(eac_df)))
         comp = ['capex_pv', 'capex_storage', 'capex_electric', 'capex_gas', 'vehicle_om']
         eac_df['total_eac'] = eac_df[comp].sum(axis=1) + bill_col
-        eac_df.to_csv(os.path.join(output_dir, f"step18_eac_summary_g{sha}.csv"), index=False)
+        merge_and_write_csv(eac_df, os.path.join(output_dir, f"step18_eac_summary_g{sha}.csv"), key_col="scenario")
         fig = plot_eac_stacked_bar(eac_df, scenario_order=scenarios)
         fig.savefig(os.path.join(output_dir, f"step18_eac_stacked_bar_g{sha}.png"), dpi=150, bbox_inches='tight')
 
@@ -237,6 +240,7 @@ def process(
         scenarios,
         counties,
         incentive='full_incentives',
+        discount_rate=discount_rate,
         electricity_plan_preference=plan_preference,
         electricity_variant='nem3',
     )
@@ -246,10 +250,12 @@ def process(
         scenarios,
         counties,
         incentive='full_incentives',
+        discount_rate=discount_rate,
         electricity_plan_preference=plan_preference,
         electricity_variant='retail',
     )
-    by_cty_nem3.to_csv(os.path.join(output_dir, f"step18_eac_by_county_nem3_g{sha}.csv"), index=False)
-    by_cty_retail.to_csv(os.path.join(output_dir, f"step18_eac_by_county_retail_g{sha}.csv"), index=False)
+    by_county_key = ["scenario", "county_slug"]
+    merge_and_write_csv(by_cty_nem3, os.path.join(output_dir, f"step18_eac_by_county_nem3_g{sha}.csv"), key_col=by_county_key)
+    merge_and_write_csv(by_cty_retail, os.path.join(output_dir, f"step18_eac_by_county_retail_g{sha}.csv"), key_col=by_county_key)
 
     return eac_df

--- a/pipeline/steps/step9b_cooptimize_core.py
+++ b/pipeline/steps/step9b_cooptimize_core.py
@@ -6,7 +6,8 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 
-from evaluations.eac import crf as _crf
+from evaluations.eac import crf as _crf, alpha_batt_npv as _alpha_batt_npv
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 try:
     import pulp
@@ -231,7 +232,7 @@ def _solve_lp(
     c_batt_kw: float = 0.0,            # $/kW PCS/inverter (optional)
     pv_life_yrs: int = 25,
     batt_life_yrs: int = 15,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     c_deg_per_kwh: float = 0.0,        # degradation cost per kWh throughput
 ) -> CooptResult:
     """Build and solve LP. Returns CooptResult with sizing, costs, and flows.
@@ -351,11 +352,13 @@ def _solve_lp(
     #   alpha_batt = K_batt / PVA(r, N)
     # alpha_batt > CRF(r, n_batt) because CRF would amortize only one purchase over n_batt years
     # and ignore the replacement cost. The difference is the discounted cost of the second battery.
-    r = float(discount_rate)
+    #
+    # These coefficients are the same ones evaluations.eac uses for EAC reporting
+    # (crf, alpha_batt_npv) — computed here via the shared primitives so the LP
+    # and the reporting layer cannot silently drift apart.
     N = int(pv_life_yrs)
-    pva_n = ((1 - (1 + r) ** (-N)) / r) if r > 0 else float(N)
-    alpha_pv = 1.0 / pva_n
-    alpha_batt = (1.0 + (1.0 + r) ** (-batt_life_yrs)) / pva_n
+    alpha_pv = _crf(discount_rate, N)
+    alpha_batt = _alpha_batt_npv(discount_rate, batt_life_yrs, N)
     capex_annual = PV_kw * c_pv_kw * alpha_pv + B_E * c_batt_kwh * alpha_batt + B_P * c_batt_kw * alpha_batt
 
     # Operating bill (imports - exports) + degradation

--- a/pipeline/steps/step9b_cooptimize_pv_battery.py
+++ b/pipeline/steps/step9b_cooptimize_pv_battery.py
@@ -92,6 +92,7 @@ from .step9b_cooptimize_core import (
     _solve_lp,
     _timestamp_index_8760,
 )
+from evaluations.constants import DEFAULT_DISCOUNT_RATE
 
 
 RATE_PLANS = {
@@ -948,7 +949,7 @@ def process(
     pv_size_sweep: Optional[List[float]] = None,
     pv_capex_sweep: Optional[List[float]] = None,
     coarse_sweeps: bool = False,
-    discount_rate: float = 0.07,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE,
     pv_capex_per_kw: float = 2830.0,
     batt_capex_per_kwh: float = 800.0,
     batt_capex_per_kw: float = 0.0,

--- a/tests/config_plumbing_test.py
+++ b/tests/config_plumbing_test.py
@@ -1,0 +1,117 @@
+"""Regression tests for Config parameters actually reaching the steps that use them.
+
+Found tonight: `Config.discount_rate` had a correct default and was correctly
+used *inside* step9b's LP and step18's EAC collection — but the module-level
+orchestration (`mod_solar_storage.run`, `mod_visualization.run`) never passed
+`cfg.discount_rate` to them at all, so the config value was silently ignored
+by the real pipeline. Same story for NBC: `calculate_nem3_annual_costs`
+accepted an `options` override, but nothing above it exposed a way to set it.
+
+These tests exercise the wiring at the module-call boundary, not the math
+inside the steps (that's covered by lp_cooptimize_test.py and friends). A
+passing test here means "the parameter you set on Config is the parameter
+the step receives," which is a different and easier-to-silently-break claim
+than "the formula is correct."
+"""
+import inspect
+import os
+import sys
+from unittest.mock import patch
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from pipeline.config import Config
+
+
+def test_solar_storage_module_passes_discount_rate_to_lp():
+    import pipeline.modules.solar_storage as mod
+
+    cfg = Config(
+        scenario="baseline_coopt",
+        housing_type="single-family-detached",
+        counties=["Alameda County"],
+        discount_rate=0.1234,
+    )
+
+    with patch.object(mod, "WeatherFiles") as mock_weather, patch.object(mod, "Step9bCoopt") as mock_step9b:
+        mod.run(cfg)
+
+    assert mock_weather.process.called
+    assert mock_step9b.process.called
+    _, kwargs = mock_step9b.process.call_args
+    assert kwargs.get("discount_rate") == 0.1234, (
+        "mod_solar_storage.run() must pass cfg.discount_rate to Step9bCoopt.process — "
+        "otherwise the LP always sizes PV/battery at its own hardcoded default "
+        "regardless of what Config specifies."
+    )
+
+
+def test_rates_capital_module_passes_nbc_override_to_step12():
+    import pipeline.modules.rates_capital as mod
+
+    cfg = Config(
+        scenario="baseline",
+        housing_type="single-family-detached",
+        counties=["Alameda County"],
+        nbc_dollars_per_kwh_override=0.0321,
+    )
+
+    with patch.object(mod, "GetLoadsForRates") as m10, \
+         patch.object(mod, "EvaluateGasRates") as m11, \
+         patch.object(mod, "EvaluateElectricityRates") as m12, \
+         patch.object(mod, "CombineTotalAnnualCosts") as m13, \
+         patch.object(mod, "BuildCapitalCostsLifetimesIncentives") as m14:
+        mod.run(cfg)
+
+    assert m12.process.called
+    _, kwargs = m12.process.call_args
+    assert kwargs.get("nbc_dollars_per_kwh_override") == 0.0321, (
+        "mod_rates_capital.run() must pass cfg.nbc_dollars_per_kwh_override to "
+        "step12 — otherwise NBC sensitivity silently has no effect on billing."
+    )
+
+
+def test_visualization_module_passes_discount_rate_to_step18():
+    """Source-level check: mocking the full mod_visualization.run() call chain
+    (steps 15-22, several with try/except branches) is disproportionate to
+    what this regression guards against. Instead assert the actual call site
+    includes discount_rate=cfg.discount_rate, which is what broke silently.
+    """
+    import pipeline.modules.visualization as mod
+
+    source = inspect.getsource(mod.run)
+    step18_call_start = source.index("Step18CrossScenarioComparisons.process(")
+    step18_call = source[step18_call_start:step18_call_start + 400]
+    assert "discount_rate=cfg.discount_rate" in step18_call, (
+        "mod_visualization.run() must pass cfg.discount_rate to "
+        "Step18CrossScenarioComparisons.process — otherwise the EAC reporting "
+        "layer always uses the default rate regardless of Config."
+    )
+
+
+def test_step12_process_forwards_nbc_override_to_nem3_calculation():
+    import pipeline.steps.step12_evaluate_electricity_rates as step12
+
+    with patch.object(step12, "process_county_scenario_nem3", wraps=step12.process_county_scenario_nem3) as spy, \
+         patch.object(step12, "process_county_scenario_from_series", return_value={}), \
+         patch.object(step12, "get_utility_for_county", return_value="PG&E"), \
+         patch.object(step12, "utility_to_rate_plans", return_value=["E-TOU-D"]), \
+         patch.object(step12, "build_results_df_with_variants", return_value={}), \
+         patch.object(step12, "update_df_with_results", side_effect=lambda df, r: df), \
+         patch.object(step12, "get_output_file_path", return_value="/dev/null"), \
+         patch.object(step12, "update_csv_with_results", side_effect=lambda path, df: df), \
+         patch("pandas.DataFrame.to_csv"):
+        try:
+            step12.process(
+                "data/loadprofiles", "data/loadprofiles", "baseline",
+                "single-family-detached", ["Alameda County"],
+                nbc_dollars_per_kwh_override=0.03,
+            )
+        except FileNotFoundError:
+            pass  # process_county_scenario_nem3 itself will hit real files; we only care it was called correctly
+
+    assert spy.called
+    _, kwargs = spy.call_args
+    assert kwargs.get("nbc_dollars_per_kwh_override") == 0.03

--- a/tests/lp_cooptimize_test.py
+++ b/tests/lp_cooptimize_test.py
@@ -36,6 +36,7 @@ from pipeline.steps.step9b_cooptimize_core import (
 )
 from helpers.nem3_export_rates import get_export_rate_table_for_county
 from helpers.electricity_rate_helpers import PGE_RATE_PLANS
+from evaluations.eac import crf, alpha_batt_npv
 
 NEM3_BASE_DIR = os.path.join(REPO_ROOT, "data", "NEM3")
 
@@ -401,4 +402,56 @@ class TestACCExportRatesBelowRetailImport:
             f"Average gap between retail and ACC should exceed $0.10/kWh "
             f"(avg_imp={avg_imp:.4f}, avg_exp={avg_exp:.4f}, gap={gap:.4f}). "
             f"A small gap would undermine the NEM3 economic penalty argument."
+        )
+
+
+# ---------------------------------------------------------------------------
+# H6 — LP capex coefficients must match the shared evaluations.eac primitives
+#
+# _solve_lp used to re-derive its NPV-framing capex coefficients (alpha_pv,
+# alpha_batt) inline instead of calling evaluations.eac.crf / alpha_batt_npv.
+# The two were mathematically identical by construction but nothing enforced
+# that they stay identical — a change to one formula could silently diverge
+# from the other. This test pins fixed PV/battery sizes (removing solver
+# choice as a variable) and asserts the LP's reported capex_annual equals the
+# primitive-computed value directly, for non-default rate/lifetimes so the
+# test can't pass by coincidentally matching a hardcoded default elsewhere.
+# ---------------------------------------------------------------------------
+class TestCapexMatchesEvaluationsPrimitives:
+    def test_lp_capex_annual_matches_crf_and_alpha_batt_npv(self):
+        inputs = CooptInputs(
+            load_kwh=H24_LOAD,
+            pv_gen_per_kw=H24_PV_PER_KW,
+            import_rates=P_IMP,
+            export_rates=P_EXP_ACC,
+        )
+        fixed_pv_kw = 3.0
+        fixed_batt_kwh = 5.0
+        c_pv_kw = 3000.0
+        c_batt_kwh = 900.0
+        discount_rate = 0.05
+        pv_life_yrs = 20
+        batt_life_yrs = 8
+
+        result = _solve_lp(
+            inputs,
+            fixed_pv_kw=fixed_pv_kw,
+            fixed_batt_kwh=fixed_batt_kwh,
+            c_pv_kw=c_pv_kw,
+            c_batt_kwh=c_batt_kwh,
+            c_batt_kw=0.0,
+            pv_life_yrs=pv_life_yrs,
+            batt_life_yrs=batt_life_yrs,
+            discount_rate=discount_rate,
+        )
+
+        expected_capex = (
+            fixed_pv_kw * c_pv_kw * crf(discount_rate, pv_life_yrs)
+            + fixed_batt_kwh * c_batt_kwh * alpha_batt_npv(discount_rate, batt_life_yrs, pv_life_yrs)
+        )
+
+        assert result.capex_annual == pytest.approx(expected_capex, rel=1e-9), (
+            "LP capex_annual has drifted from evaluations.eac.crf/alpha_batt_npv — "
+            "the LP must compute its NPV-framing capex coefficients via the shared "
+            "primitives, not a local re-derivation."
         )

--- a/tests/merge_and_write_csv_test.py
+++ b/tests/merge_and_write_csv_test.py
@@ -1,0 +1,105 @@
+"""Regression test for the shared merge-on-write CSV helper.
+
+Several pipeline outputs (capital_costs ledgers in step14, cross-scenario
+exports in step18) are single shared files covering every county for a
+scenario, but call sites are typically invoked with a subset of counties at a
+time. Writing with a plain `to_csv` silently discarded every county not in
+the current run (a real incident: an Alameda county row was lost this way
+while extending a 1-county analysis to 3 more counties).
+`merge_and_write_csv` must preserve untouched counties and only refresh rows
+for the counties actually present in the current write. It lives in
+helpers/main_helpers.py so step14 and step18 share one implementation instead
+of two copies that could drift.
+"""
+import os
+import sys
+
+import pandas as pd
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from helpers.main_helpers import merge_and_write_csv
+
+
+def test_second_write_preserves_first_countys_rows(tmp_path):
+    path = os.path.join(tmp_path, "capital_costs_test_scenario.csv")
+
+    first = pd.DataFrame({"county_slug": ["alameda"], "total_eac": [100.0]})
+    merge_and_write_csv(first, path)
+
+    second = pd.DataFrame({"county_slug": ["fresno", "los-angeles"], "total_eac": [200.0, 300.0]})
+    merge_and_write_csv(second, path)
+
+    result = pd.read_csv(path)
+    assert set(result["county_slug"]) == {"alameda", "fresno", "los-angeles"}
+
+
+def test_rewriting_an_existing_county_refreshes_not_duplicates(tmp_path):
+    path = os.path.join(tmp_path, "capital_costs_test_scenario.csv")
+
+    first = pd.DataFrame({"county_slug": ["alameda"], "total_eac": [100.0]})
+    merge_and_write_csv(first, path)
+
+    refreshed = pd.DataFrame({"county_slug": ["alameda"], "total_eac": [999.0]})
+    merge_and_write_csv(refreshed, path)
+
+    result = pd.read_csv(path)
+    assert len(result) == 1
+    assert result.iloc[0]["total_eac"] == 999.0
+
+
+def test_first_write_with_no_existing_file(tmp_path):
+    path = os.path.join(tmp_path, "capital_costs_test_scenario.csv")
+
+    first = pd.DataFrame({"county_slug": ["san-diego"], "total_eac": [50.0]})
+    merge_and_write_csv(first, path)
+
+    result = pd.read_csv(path)
+    assert list(result["county_slug"]) == ["san-diego"]
+
+
+def test_composite_key_preserves_other_scenarios_for_same_county(tmp_path):
+    """step18's by-county exports have one row per (scenario, county) — keying
+    on county_slug alone would wrongly drop a county's other-scenario rows
+    when a later run recomputes that county under a different scenario list.
+    """
+    path = os.path.join(tmp_path, "step18_eac_by_county_nem3.csv")
+
+    first = pd.DataFrame({
+        "scenario": ["baseline", "full_electric_ev"],
+        "county_slug": ["alameda", "alameda"],
+        "total_eac": [100.0, 200.0],
+    })
+    merge_and_write_csv(first, path, key_col=["scenario", "county_slug"])
+
+    # A later run recomputes only "full_electric_ev" for alameda, plus a new county.
+    second = pd.DataFrame({
+        "scenario": ["full_electric_ev", "full_electric_ev"],
+        "county_slug": ["alameda", "fresno"],
+        "total_eac": [999.0, 300.0],
+    })
+    merge_and_write_csv(second, path, key_col=["scenario", "county_slug"])
+
+    result = pd.read_csv(path)
+    pairs = set(zip(result["scenario"], result["county_slug"]))
+    assert pairs == {
+        ("baseline", "alameda"),
+        ("full_electric_ev", "alameda"),
+        ("full_electric_ev", "fresno"),
+    }
+    refreshed = result[(result["scenario"] == "full_electric_ev") & (result["county_slug"] == "alameda")]
+    assert refreshed.iloc[0]["total_eac"] == 999.0
+
+
+def test_missing_key_column_in_existing_file_does_not_crash(tmp_path):
+    """If an existing file predates the key column, don't error — just overwrite."""
+    path = os.path.join(tmp_path, "legacy.csv")
+    pd.DataFrame({"other_col": [1, 2]}).to_csv(path, index=False)
+
+    incoming = pd.DataFrame({"county_slug": ["napa"], "total_eac": [10.0]})
+    merge_and_write_csv(incoming, path)
+
+    result = pd.read_csv(path)
+    assert list(result["county_slug"]) == ["napa"]

--- a/tests/sensitivity_registry_test.py
+++ b/tests/sensitivity_registry_test.py
@@ -1,0 +1,46 @@
+"""Tests for the sensitivity parameter registry (evaluations/sensitivity.py).
+
+Pure structural checks — no pipeline execution. See
+sensitivity_runner_test.py for orchestration behavior.
+"""
+import dataclasses
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+from evaluations.sensitivity import SENSITIVITY_PARAMETERS
+from pipeline.config import Config
+
+
+def test_registry_has_discount_rate_and_nbc():
+    assert "discount_rate" in SENSITIVITY_PARAMETERS
+    assert "nbc_dollars_per_kwh" in SENSITIVITY_PARAMETERS
+
+
+def test_every_registered_config_field_exists_on_config():
+    """If a registry entry points at a Config field that doesn't exist,
+    run_sensitivity would fail with a cryptic TypeError deep inside a sweep
+    instead of failing fast and clearly."""
+    config_fields = {f.name for f in dataclasses.fields(Config)}
+    for name, param in SENSITIVITY_PARAMETERS.items():
+        assert param.config_field in config_fields, (
+            f"SensitivityParameter '{name}' points at Config.{param.config_field}, "
+            f"which does not exist on Config."
+        )
+
+
+def test_discount_rate_requires_lp_resolve():
+    """Discount rate changes the LP's optimal PV/battery sizing, not just
+    report-time annualization — a sweep that skipped the LP resolve would
+    silently report the wrong sizes for every rate except the default."""
+    assert SENSITIVITY_PARAMETERS["discount_rate"].requires_lp_resolve is True
+
+
+def test_nbc_does_not_require_lp_resolve():
+    """Documents the current methodology: NBC affects only step12 billing,
+    not the LP's price series. If this ever changes, this test should be
+    updated deliberately alongside the LP wiring, not silently."""
+    assert SENSITIVITY_PARAMETERS["nbc_dollars_per_kwh"].requires_lp_resolve is False

--- a/tests/sensitivity_runner_test.py
+++ b/tests/sensitivity_runner_test.py
@@ -1,0 +1,118 @@
+"""Orchestration tests for pipeline.sensitivity_runner.run_sensitivity.
+
+Mocks the actual pipeline modules and data access so these run fast and
+don't require real county data or an LP solve — they verify *which
+functions get called with what arguments*, not the underlying math (that's
+covered by lp_cooptimize_test.py and evaluations_methods_test.py).
+"""
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+import pipeline.sensitivity_runner as runner
+
+
+def _fake_by_county_df(counties, scenarios):
+    rows = []
+    for c in counties:
+        for s in scenarios:
+            rows.append({
+                "scenario": s,
+                "county_slug": c,
+                "capex_pv": 100.0,
+                "capex_storage": 50.0,
+                "capex_electric": 200.0,
+                "capex_gas": 0.0,
+                "annual_bill_electric": 500.0,
+                "annual_bill_gas": 0.0,
+                "vehicle_om": 0.0,
+            })
+    return pd.DataFrame(rows)
+
+
+def test_discount_rate_sweep_calls_lp_resolve_for_each_value():
+    with patch.object(runner, "mod_solar_storage") as mock_solar, \
+         patch.object(runner, "mod_rates_capital") as mock_rates, \
+         patch.object(runner, "collect_eac_components_by_county") as mock_collect, \
+         patch.object(runner, "merge_and_write_csv") as mock_write:
+        mock_collect.side_effect = lambda *a, **k: _fake_by_county_df(["alameda"], ["baseline_coopt"])
+
+        runner.run_sensitivity(
+            "discount_rate",
+            [0.03, 0.07, 0.10],
+            scenario="baseline_coopt",
+            sibling_scenarios=["baseline_coopt"],
+            counties=["Alameda County"],
+        )
+
+    assert mock_solar.run.call_count == 3, "discount_rate requires an LP resolve for every swept value"
+    assert mock_rates.run.call_count == 3
+    rates_seen = [call.args[0].discount_rate for call in mock_solar.run.call_args_list]
+    assert rates_seen == [0.03, 0.07, 0.10]
+
+
+def test_nbc_sweep_never_calls_lp_resolve():
+    with patch.object(runner, "mod_solar_storage") as mock_solar, \
+         patch.object(runner, "mod_rates_capital") as mock_rates, \
+         patch.object(runner, "collect_eac_components_by_county") as mock_collect, \
+         patch.object(runner, "merge_and_write_csv"):
+        mock_collect.side_effect = lambda *a, **k: _fake_by_county_df(["alameda"], ["baseline"])
+
+        runner.run_sensitivity(
+            "nbc_dollars_per_kwh",
+            [0.0, 0.02, 0.03],
+            scenario="baseline",
+            sibling_scenarios=["baseline"],
+            counties=["Alameda County"],
+        )
+
+    assert mock_solar.run.call_count == 0, (
+        "NBC sensitivity must not re-solve the LP (see SENSITIVITY_PARAMETERS docstring) — "
+        "if this now fails, the methodology decision changed and this test should be updated deliberately"
+    )
+    assert mock_rates.run.call_count == 3
+    nbc_seen = [call.args[0].nbc_dollars_per_kwh_override for call in mock_rates.run.call_args_list]
+    assert nbc_seen == [0.0, 0.02, 0.03]
+
+
+def test_output_is_tagged_and_written_with_composite_key():
+    with patch.object(runner, "mod_solar_storage"), \
+         patch.object(runner, "mod_rates_capital"), \
+         patch.object(runner, "collect_eac_components_by_county") as mock_collect, \
+         patch.object(runner, "merge_and_write_csv") as mock_write:
+        mock_collect.side_effect = lambda *a, **k: _fake_by_county_df(["alameda", "fresno"], ["baseline_coopt"])
+
+        result = runner.run_sensitivity(
+            "discount_rate",
+            [0.05],
+            scenario="baseline_coopt",
+            sibling_scenarios=["baseline_coopt"],
+            counties=["Alameda County", "Fresno County"],
+        )
+
+    assert set(result["parameter"]) == {"discount_rate"}
+    assert set(result["value"]) == {0.05}
+    assert "total_eac" in result.columns
+    assert (result["total_eac"] > 0).all()
+
+    assert mock_write.called
+    _, kwargs = mock_write.call_args
+    assert kwargs.get("key_col") == ["parameter", "value", "scenario", "county_slug"]
+
+
+def test_unknown_parameter_raises_clear_error():
+    with pytest.raises(ValueError, match="Unknown sensitivity parameter"):
+        runner.run_sensitivity(
+            "not_a_real_parameter",
+            [1, 2],
+            scenario="baseline",
+            sibling_scenarios=["baseline"],
+            counties=["Alameda County"],
+        )


### PR DESCRIPTION
(1) Add discount rate constant and propagate it through files
- Previously we were passing a discount rate value around, but it could potentially be different, or override arguments, in various files. The first set of changes fixes that. 
(2) Add merge_and_write_csv to not overwrite old ledger entries, when ledger entries for a new county are generated. 
(3) Start evaluating electricity rates with NBC / before NEM3 credits
(4) Add sensitivity params to evals