### PR TITLE
Fix data sources for heat pumps, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 data/*
 !data/NEM3/
+# Source data for heat pump capex (TECH Clean California, per county) — drives
+# the largest capex line item in every electrified scenario; must be tracked
+# and reproducible, not silently missing on a fresh clone.
+!data/County_Median_HPSH_Stats.csv
+!data/County_Median_HPWH_Stats.csv
 # Load profiles committed for CI testing (nem3_billing_test.py)
 !data/loadprofiles/
 data/loadprofiles/*

--- a/appliances/battery_storage.py
+++ b/appliances/battery_storage.py
@@ -42,6 +42,17 @@ class BatteryStorageAppliance(ElectricAppliance):
         unit = cls(num_units=1)
         return unit.base_cost / unit.capacity_kwh
 
+    @classmethod
+    def per_kwh_cost_net(cls, scenario: IncentiveScenario) -> float:
+        """Net (after-incentive) $/kWh under the given incentive scenario.
+
+        Use this — not per_kwh_cost() — for a sizing decision meant to reflect
+        what the modeled decision-maker actually pays, e.g. the LP's default
+        sizing signal, which should match whichever incentive scenario is the
+        one actually being reported (2026-07-07)."""
+        unit = cls(num_units=1)
+        return unit.get_net_cost(scenario) / unit.capacity_kwh
+
     def get_cost_breakdown(self, scenario: IncentiveScenario = IncentiveScenario.FULL_INCENTIVES) -> Dict:
         """Return detailed cost breakdown for battery storage."""
         total_incentives = self.calculate_total_incentives(scenario)

--- a/appliances/battery_storage.py
+++ b/appliances/battery_storage.py
@@ -32,7 +32,16 @@ class BatteryStorageAppliance(ElectricAppliance):
                 source_url="https://www.energy.gov/eere/solar/homeowners-guide-federal-tax-credit-solar-photovoltaics"
             )
             self.add_incentive(federal_tax_credit)
-    
+
+    @classmethod
+    def per_kwh_cost(cls) -> float:
+        """Gross (pre-incentive) $/kWh, derived from the same unit economics as
+        every other capex figure for this appliance — the single number any
+        caller (the LP's sizing objective, step14's reporting) should use for
+        battery cost per kWh, so sizing and reporting can't silently diverge."""
+        unit = cls(num_units=1)
+        return unit.base_cost / unit.capacity_kwh
+
     def get_cost_breakdown(self, scenario: IncentiveScenario = IncentiveScenario.FULL_INCENTIVES) -> Dict:
         """Return detailed cost breakdown for battery storage."""
         total_incentives = self.calculate_total_incentives(scenario)

--- a/appliances/electric_cooking.py
+++ b/appliances/electric_cooking.py
@@ -10,8 +10,12 @@ from typing import Dict
 from appliances.electric_base import ElectricAppliance, Incentive, IncentiveScenario
 
 class ElectricCookingAppliance(ElectricAppliance):
-    def __init__(self, 
+    def __init__(self,
                  cooking_type: str = "induction",
+                 # CARB appliance comparison data ("Cristina's approach" — see Simon La
+                 # Vieille, "EV Integration to Ana's Project," Aug 2025): capital $2,400 +
+                 # installation $1,380 + other $340 = $4,120 (2022), inflated 3.4% CPI-U
+                 # to 2023 = $4,260.08.
                  base_cost: float = 4260.08,
                  lifetime_years: int = 15):
         super().__init__(f"electric_{cooking_type}_cooking", base_cost, lifetime_years)

--- a/appliances/electric_heating.py
+++ b/appliances/electric_heating.py
@@ -5,6 +5,19 @@ from appliances.electric_base import ElectricAppliance, IncentiveScenario
 from helpers.main_helpers import slugify_county_name
 
 class ElectricHeatingAppliance(ElectricAppliance):
+    """County-aware heat pump space heating appliance.
+
+    Cost data source: TECH Clean California program data (CEC), filtered to
+    ducted systems only (AHRI types without the "-O" suffix — see Simon La
+    Vieille, "EV Integration to Ana's Project," Aug 2025). Values are
+    contractor/turnkey costs (equipment + installation), not equipment-only.
+    3 of the pipeline's 47 counties (mono, plumas, sierra) are absent from
+    the source data; those use the median of the counties present, per the
+    same report's documented approach ("take the state median to fill in
+    the gaps") — computed here, not hardcoded, so it stays correct if the
+    source data is refreshed.
+    """
+
     CONFIG_PATH = os.path.join(
         os.path.dirname(__file__), "..", "data", "County_Median_HPSH_Stats.csv"
     )
@@ -55,6 +68,14 @@ class ElectricHeatingAppliance(ElectricAppliance):
         return cls._CONFIG_DF
 
     @classmethod
+    def _state_median_row(cls, df: pd.DataFrame) -> pd.Series:
+        """Median of all counties present, for counties missing from the source data."""
+        return pd.Series({
+            cls.CAPITAL_COST_COLUMN_NAME: df[cls.CAPITAL_COST_COLUMN_NAME].median(),
+            cls.INCENTIVE_COLUMN_NAME: df[cls.INCENTIVE_COLUMN_NAME].median(),
+        })
+
+    @classmethod
     def for_county(cls, county_slug: str, heating_type: str = "heat_pump") -> "ElectricHeatingAppliance":
         """
         Factory that reads county-specific base_cost from CSV.
@@ -64,14 +85,8 @@ class ElectricHeatingAppliance(ElectricAppliance):
 
         if county_slug in df.index:
             row = df.loc[county_slug]
-        elif "statewide" in df.index:
-            row = df.loc["statewide"]
         else:
-            # final fallback
-            row = pd.Series({
-                cls.CAPITAL_COST_COLUMN_NAME: 19000.0,
-                cls.INCENTIVE_COLUMN_NAME: 0.0,
-            })
+            row = cls._state_median_row(df)
 
         base_cost = float(row[cls.CAPITAL_COST_COLUMN_NAME])
         inst = cls(heating_type=heating_type, base_cost=base_cost, lifetime_years=15)
@@ -91,8 +106,10 @@ class ElectricHeatingAppliance(ElectricAppliance):
         
         # Add county-specific incentives from CSV data
         df = self._load_config()
-        key = self.county_slug if (self.county_slug in df.index) else ("statewide" if "statewide" in df.index else df.index[0])
-        csv_inc_full = float(df.loc[key, self.INCENTIVE_COLUMN_NAME])
+        if self.county_slug in df.index:
+            csv_inc_full = float(df.loc[self.county_slug, self.INCENTIVE_COLUMN_NAME])
+        else:
+            csv_inc_full = float(self._state_median_row(df)[self.INCENTIVE_COLUMN_NAME])
 
         # Apply scenario multiplier to CSV incentives
         if scenario == IncentiveScenario.FULL_INCENTIVES:

--- a/appliances/electric_water_heating.py
+++ b/appliances/electric_water_heating.py
@@ -5,8 +5,17 @@ from appliances.electric_base import ElectricAppliance, IncentiveScenario
 from helpers.main_helpers import slugify_county_name
 
 class ElectricWaterHeatingAppliance(ElectricAppliance):
-    """
-    County-aware electric water heating appliance.
+    """County-aware heat pump water heater appliance.
+
+    Cost data source: TECH Clean California program data (CEC), filtered to
+    Single Family installs of Heat Pump Water Heater / Split System HPWH /
+    120V and 240V integrated HPWH (see Simon La Vieille, "EV Integration to
+    Ana's Project," Aug 2025). Values are contractor/turnkey costs
+    (equipment + installation), not equipment-only. 9 of the pipeline's 47
+    counties are absent from the source data; those use the median of the
+    counties present, per the same report's documented approach ("take the
+    state median to fill in the gaps") — computed here, not hardcoded, so it
+    stays correct if the source data is refreshed.
     """
 
     CONFIG_PATH = os.path.join(
@@ -60,18 +69,21 @@ class ElectricWaterHeatingAppliance(ElectricAppliance):
         return cls._CONFIG_DF
 
     @classmethod
+    def _state_median_row(cls, df: pd.DataFrame) -> pd.Series:
+        """Median of all counties present, for counties missing from the source data."""
+        return pd.Series({
+            cls.CAPITAL_COST_COLUMN_NAME: df[cls.CAPITAL_COST_COLUMN_NAME].median(),
+            cls.INCENTIVE_COLUMN_NAME: df[cls.INCENTIVE_COLUMN_NAME].median(),
+        })
+
+    @classmethod
     def for_county(cls, county_slug: str, heater_type: str = "heat_pump") -> "ElectricWaterHeatingAppliance":
         df = cls._load_config()
 
         if county_slug in df.index:
             row = df.loc[county_slug]
-        elif "statewide" in df.index:
-            row = df.loc["statewide"]
         else:
-            row = pd.Series({
-                cls.CAPITAL_COST_COLUMN_NAME: 2637.0,
-                cls.INCENTIVE_COLUMN_NAME: 0.0,
-            })
+            row = cls._state_median_row(df)
 
         base_cost = float(row[cls.CAPITAL_COST_COLUMN_NAME])
         inst = cls(heater_type=heater_type, base_cost=base_cost, lifetime_years=15)
@@ -87,8 +99,10 @@ class ElectricWaterHeatingAppliance(ElectricAppliance):
         
         # Add county-specific incentives from CSV data
         df = self._load_config()
-        key = self.county_slug if (self.county_slug in df.index) else ("statewide" if "statewide" in df.index else df.index[0])
-        csv_inc_full = float(df.loc[key, self.INCENTIVE_COLUMN_NAME])
+        if self.county_slug in df.index:
+            csv_inc_full = float(df.loc[self.county_slug, self.INCENTIVE_COLUMN_NAME])
+        else:
+            csv_inc_full = float(self._state_median_row(df)[self.INCENTIVE_COLUMN_NAME])
 
         # Apply scenario multiplier to CSV incentives
         if scenario == IncentiveScenario.FULL_INCENTIVES:

--- a/appliances/gas_heating.py
+++ b/appliances/gas_heating.py
@@ -26,7 +26,13 @@ class GasHeatingAppliance(GasAppliance):
         
         Args:
             heating_type: Type of gas heating system (default: "furnace")
-            base_cost: Base equipment and installation cost in dollars
+            base_cost: Base equipment and installation cost in dollars.
+                CARB appliance comparison data ("Cristina's approach" — see Simon
+                La Vieille, "EV Integration to Ana's Project," Aug 2025): capital
+                $4,500 + installation $4,180 + other $770 = $9,450 (2022), inflated
+                3.4% CPI-U to 2023 = $9,771.30. This is "Gas HVAC" in that report —
+                confirm it's the intended comparison point if the paper ever
+                narrows scope to heating-only (vs. full HVAC).
             lifetime_years: Expected equipment lifetime in years
             efficiency: Gas furnace efficiency (typically ~83% AFUE)
         """

--- a/appliances/gas_stove.py
+++ b/appliances/gas_stove.py
@@ -2,17 +2,21 @@ from typing import Dict
 from appliances.gas_base import GasAppliance
 
 class GasStoveAppliance(GasAppliance):
-    def __init__(self, 
+    def __init__(self,
                  stove_type: str = "gas",
                  base_cost: float = 2802.14,
                  lifetime_years: int = 15,
                  efficiency: float = 0.45):
         """
         Initialize gas stove appliance.
-        
+
         Args:
             stove_type: Type of gas cooking system (default: "gas")
-            base_cost: Base equipment and installation cost in dollars
+            base_cost: Base equipment and installation cost in dollars.
+                CARB appliance comparison data ("Cristina's approach" — see Simon
+                La Vieille, "EV Integration to Ana's Project," Aug 2025): capital
+                $1,600 + installation $890 + other $220 = $2,710 (2022), inflated
+                3.4% CPI-U to 2023 = $2,802.14.
             lifetime_years: Expected equipment lifetime in years
             efficiency: Gas stove efficiency (typically ~45% for cooking)
         """

--- a/appliances/gas_water_heating.py
+++ b/appliances/gas_water_heating.py
@@ -27,7 +27,11 @@ class GasWaterHeatingAppliance(GasAppliance):
         
         Args:
             heater_type: Type of gas water heating system (default: "tank")
-            base_cost: Base equipment and installation cost in dollars
+            base_cost: Base equipment and installation cost in dollars.
+                CARB appliance comparison data ("Cristina's approach" — see Simon
+                La Vieille, "EV Integration to Ana's Project," Aug 2025): capital
+                $900 + installation $1,200 + other $90 = $2,190 (2022), inflated
+                3.4% CPI-U to 2023 = $2,264.46.
             lifetime_years: Expected equipment lifetime in years
             efficiency: Gas water heater efficiency (typically ~83% AFUE)
             capacity_gallons: Water heater tank capacity in gallons

--- a/appliances/solar_system.py
+++ b/appliances/solar_system.py
@@ -42,6 +42,17 @@ class SolarSystemAppliance(ElectricAppliance):
         unit = cls(capacity_kw=1.0)
         return unit.base_cost
 
+    @classmethod
+    def per_kw_cost_net(cls, scenario: IncentiveScenario) -> float:
+        """Net (after-incentive) $/kW under the given incentive scenario.
+
+        Use this — not per_kw_cost() — for a sizing decision meant to reflect
+        what the modeled decision-maker actually pays, e.g. the LP's default
+        sizing signal, which should match whichever incentive scenario is the
+        one actually being reported (2026-07-07)."""
+        unit = cls(capacity_kw=1.0)
+        return unit.get_net_cost(scenario)
+
     def get_cost_breakdown(self, scenario: IncentiveScenario = IncentiveScenario.FULL_INCENTIVES) -> Dict:
         """Return detailed cost breakdown for solar system."""
         total_incentives = self.calculate_total_incentives(scenario)

--- a/appliances/solar_system.py
+++ b/appliances/solar_system.py
@@ -32,7 +32,16 @@ class SolarSystemAppliance(ElectricAppliance):
             source_url="https://www.energy.gov/eere/solar/homeowners-guide-federal-tax-credit-solar-photovoltaics"
         )
         self.add_incentive(federal_tax_credit)
-    
+
+    @classmethod
+    def per_kw_cost(cls) -> float:
+        """Gross (pre-incentive) $/kW, derived from the same unit economics as
+        every other capex figure for this appliance — the single number any
+        caller (the LP's sizing objective, step14's reporting) should use for
+        PV cost per kW, so sizing and reporting can't silently diverge."""
+        unit = cls(capacity_kw=1.0)
+        return unit.base_cost
+
     def get_cost_breakdown(self, scenario: IncentiveScenario = IncentiveScenario.FULL_INCENTIVES) -> Dict:
         """Return detailed cost breakdown for solar system."""
         total_incentives = self.calculate_total_incentives(scenario)

--- a/data/County_Median_HPSH_Stats.csv
+++ b/data/County_Median_HPSH_Stats.csv
@@ -1,0 +1,55 @@
+County,Total Project Cost per Unit ($),Total Incentive Received by Contractor ($),Uniform Energy Factor
+Alameda County,20855.0,1000.0,3.5
+Alpine County,24962.0,1000.0,
+Amador County,22291.5,1250.0,3.45
+Butte County,16500.0,1000.0,3.45
+Calaveras County,21054.7,1000.0,3.75
+Colusa County,17720.0,3000.0,3.42
+Contra Costa County,22413.5,1000.0,3.75
+Del Norte County,10212.0,8200.0,
+El Dorado County,23892.9,1000.0,3.39
+Fresno County,21249.0,1000.0,3.45
+Glenn County,16280.0,1000.0,
+Humboldt County,18350.0,1000.0,
+Imperial County,14448.0,3000.0,
+Kern County,16185.0,1000.0,3.0
+Kings County,19162.0,1000.0,
+Lake County,18814.5,1000.0,
+Lassen County,11924.5,1000.0,
+Los Angeles County,19800.0,1000.0,3.59
+Madera County,20003.65,1000.0,3.75
+Marin County,23729.0,1000.0,3.75
+Mariposa County,17050.2,1000.0,
+Mendocino County,18128.0,3800.0,3.85
+Merced County,16675.1,1000.0,3.57
+Monterey County,16000.0,2500.0,3.75
+Napa County,20616.75,1000.0,3.8
+Nevada County,16953.0,1000.0,
+Orange County,17242.04,1000.0,3.5
+Placer County,21287.0,1000.0,3.45
+Riverside County,16042.63,1000.0,3.46
+Sacramento County,20022.0,1000.0,3.46
+San Benito County,19773.84,1250.0,
+San Bernardino County,21427.36,1000.0,3.75
+San Diego County,16415.15,1000.0,3.75
+San Francisco County,18555.05,1000.0,3.75
+San Joaquin County,20726.0,1000.0,3.62
+San Luis Obispo County,16882.0,3000.0,3.45
+San Mateo County,19657.46,1000.0,3.75
+Santa Barbara County,18531.0,3000.0,3.88
+Santa Clara County,19956.0,1000.0,3.75
+Santa Cruz County,19393.47,3500.0,3.88
+Shasta County,16666.0,1000.0,3.45
+Siskiyou County,38457.0,1000.0,
+Solano County,21448.0,1000.0,3.46
+Sonoma County,23000.0,1000.0,3.75
+Stanislaus County,18011.0,1000.0,3.39
+Sutter County,19444.0,1000.0,3.39
+Tehama County,16523.0,1000.0,3.45
+Trinity County,17085.0,1000.0,
+Tulare County,24416.07,1000.0,
+Tuolumne County,19980.0,1000.0,3.75
+Ventura County,21181.5,1000.0,3.56
+Yolo County,20332.5,1000.0,3.75
+Yuba County,19503.5,1000.0,3.57
+California Median,19444.0,1000.0,3.57

--- a/data/County_Median_HPWH_Stats.csv
+++ b/data/County_Median_HPWH_Stats.csv
@@ -1,0 +1,47 @@
+County,Total Project Cost per Unit ($),Total Incentive Received by Contractor ($),Uniform Energy Factor
+Alameda County,7977.0,4200.0,3.64
+Amador County,5400.0,3100.0,3.45
+Butte County,4550.0,3100.0,3.7
+Calaveras County,6568.0,3800.0,4.05
+Colusa County,4592.3,4500.0,3.42
+Contra Costa County,7977.0,4000.0,3.75
+El Dorado County,5671.0,3800.0,3.7
+Fresno County,8742.0,8740.0,4.05
+Glenn County,4750.0,3100.0,3.8
+Kern County,3931.37,3800.0,3.3
+Kings County,8885.0,8885.0,4.05
+Lake County,14132.6,4800.0,4.06
+Los Angeles County,5016.54,4185.0,3.8
+Madera County,7775.0,7775.0,3.75
+Marin County,9187.5,3800.0,3.85
+Mendocino County,7950.0,3825.0,3.92
+Merced County,8905.0,8685.0,3.64
+Monterey County,6950.0,6500.0,3.88
+Napa County,7994.5,3100.0,3.8
+Nevada County,8302.29,4842.5,3.79
+Orange County,5372.0,3800.0,3.75
+Placer County,5976.0,3800.0,3.7
+Riverside County,7818.0,6968.0,4.05
+Sacramento County,6600.0,6300.0,3.7
+San Bernardino County,4183.47,3800.0,3.75
+San Diego County,8885.0,5322.75,3.83
+San Francisco County,9100.0,5700.0,3.7
+San Joaquin County,7385.0,4700.0,3.64
+San Luis Obispo County,7536.8,5300.0,3.7
+San Mateo County,7869.0,5800.0,3.75
+Santa Barbara County,6490.39,6385.0,3.88
+Santa Clara County,7449.56,4700.0,3.8
+Santa Cruz County,8201.87,5300.0,3.88
+Shasta County,5500.0,3800.0,3.64
+Siskiyou County,5100.0,3800.0,3.64
+Solano County,7700.0,4800.0,3.75
+Sonoma County,7700.0,4000.0,3.85
+Stanislaus County,6231.64,3100.0,3.44
+Sutter County,4900.0,3800.0,3.7
+Tehama County,6476.5,4500.0,3.45
+Tulare County,8885.0,8885.0,4.05
+Tuolumne County,5873.0,3800.0,3.88
+Ventura County,7624.0,4700.0,3.64
+Yolo County,6997.0,4100.0,3.75
+Yuba County,6032.46,3100.0,3.57
+California Median,7385.0,4200.0,3.75

--- a/docs/methods.yaml
+++ b/docs/methods.yaml
@@ -251,5 +251,74 @@
     "code": [
       "evaluations/lcoe.py:lcoe_from_schedules"
     ]
+  },
+  "appliances.solar_system": {
+    "title": "Solar PV Installed Cost",
+    "formula": "total_cost = capacity_kw * 1000 * $3.30/W",
+    "data_sources": {
+      "rate": "$3.30/W, CPUC-adopted 2023 California solar cost (docs.cpuc.ca.gov/PublishedDocs/Published/G000/M499/K921/499921246.PDF). Reconciles NREL ATB ($2.34/W, too low) vs. LBNL Tracking the Sun 2019 ($3.80/W, too high); accounts for panel upgrades, delays, inflation."
+    },
+    "assumptions": {
+      "sizing_vs_reporting": "SolarSystemAppliance.per_kw_cost() is the single source of truth for this rate — the LP's sizing objective (step9b) must use the same value the reporting layer (step14) uses, or the LP optimizes against a price it isn't actually charged. Bug found and fixed 2026-07-06."
+    },
+    "code": [
+      "appliances/solar_system.py:SolarSystemAppliance",
+      "appliances/solar_system.py:per_kw_cost"
+    ]
+  },
+  "appliances.battery_storage": {
+    "title": "Battery Storage Installed Cost",
+    "formula": "total_cost = num_units * $18,258 (12.5 kWh/unit)",
+    "data_sources": {
+      "rate": "NREL ATB 2024 moderate scenario, residential 5kW/12.5kWh system, as used in CEC-200-2024-011 (energy.ca.gov/sites/default/files/2024-07/CEC-200-2024-011.pdf). ATB via atb.nrel.gov/electricity/2024/data."
+    },
+    "assumptions": {
+      "sizing_vs_reporting": "BatteryStorageAppliance.per_kwh_cost() is the single source of truth for this rate — see appliances.solar_system note. Bug found and fixed 2026-07-06: LP previously sized against a stale $800/kWh default while this reporting rate was ~$1,461/kWh gross."
+    },
+    "code": [
+      "appliances/battery_storage.py:BatteryStorageAppliance",
+      "appliances/battery_storage.py:per_kwh_cost"
+    ]
+  },
+  "appliances.electric_heating": {
+    "title": "Heat Pump Space Heating Installed Cost (per county)",
+    "formula": "base_cost = County_Median_HPSH_Stats.csv[county]['Total Project Cost per Unit ($)']",
+    "data_sources": {
+      "source": "TECH Clean California program data (CEC), filtered to ducted systems only (AHRI types without the '-O' suffix). Contractor/turnkey cost, not equipment-only. See Simon La Vieille, 'EV Integration to Ana's Project' (Aug 2025), section 'Heat Pump - Space Heater'.",
+      "file": "data/County_Median_HPSH_Stats.csv",
+      "missing_counties": "3 of the pipeline's 47 counties (mono, plumas, sierra) absent from source; filled with the median of counties present (computed in for_county(), not hardcoded)."
+    },
+    "code": [
+      "appliances/electric_heating.py:for_county"
+    ]
+  },
+  "appliances.electric_water_heating": {
+    "title": "Heat Pump Water Heater Installed Cost (per county)",
+    "formula": "base_cost = County_Median_HPWH_Stats.csv[county]['Total Project Cost per Unit ($)']",
+    "data_sources": {
+      "source": "TECH Clean California program data (CEC), Single Family installs of Heat Pump Water Heater / Split System HPWH / 120V and 240V integrated HPWH. Contractor/turnkey cost. See Simon La Vieille, 'EV Integration to Ana's Project' (Aug 2025), section 'Heat Pump Water Heater'.",
+      "file": "data/County_Median_HPWH_Stats.csv",
+      "missing_counties": "9 of the pipeline's 47 counties absent from source; filled with the median of counties present (computed in for_county(), not hardcoded)."
+    },
+    "code": [
+      "appliances/electric_water_heating.py:for_county"
+    ]
+  },
+  "appliances.carb_appliance_costs": {
+    "title": "Induction Stove / Gas Appliance Installed Costs",
+    "formula": "base_cost_2023 = (capital + installation + other)_2022 * 1.034",
+    "data_sources": {
+      "source": "CARB appliance comparison data ('Cristina's approach'), 3.4% CPI-U inflation applied to bring 2022 figures to 2023. See Simon La Vieille, 'EV Integration to Ana's Project' (Aug 2025), section 'Rest of the Values'.",
+      "induction_stove": "$2,400 + $1,380 + $340 = $4,120 (2022) -> $4,260.08 (2023)",
+      "gas_stove": "$1,600 + $890 + $220 = $2,710 (2022) -> $2,802.14 (2023)",
+      "gas_water_heater": "$900 + $1,200 + $90 = $2,190 (2022) -> $2,264.46 (2023)",
+      "gas_heating": "$4,500 + $4,180 + $770 = $9,450 (2022) -> $9,771.30 (2023) — reported as 'Gas HVAC' in the source; confirm scope (heating-only vs. full HVAC incl. AC) matches intended use."
+    },
+    "code": [
+      "appliances/electric_cooking.py:ElectricCookingAppliance",
+      "appliances/gas_stove.py:GasStoveAppliance",
+      "appliances/gas_water_heating.py:GasWaterHeatingAppliance",
+      "appliances/gas_heating.py:GasHeatingAppliance"
+    ]
   }
 }

--- a/pipeline/modules/solar_storage/__init__.py
+++ b/pipeline/modules/solar_storage/__init__.py
@@ -9,6 +9,9 @@ from helpers.main_helpers import log_step, slugify_county_name
 from pipeline.steps import step8_get_weather_files as WeatherFiles
 from pipeline.steps import step9_my_own_solar_storage as Step9MyOwnSolarStorage
 from pipeline.steps import step9b_cooptimize_pv_battery as Step9bCoopt
+from appliances.solar_system import SolarSystemAppliance
+from appliances.battery_storage import BatteryStorageAppliance
+from appliances.electric_base import IncentiveScenario
 
 
 def _is_coopt_scenario(name: str) -> bool:
@@ -42,6 +45,12 @@ def run(cfg: Config) -> None:
     # 9) PV/Storage modeling
     log_step(9)
     if _is_coopt_scenario(cfg.scenario):
+        # The LP's sizing decision should reflect what the modeled
+        # decision-maker actually pays under the incentive scenario being
+        # run — not a fixed default that only matches full_incentives.
+        # See step9b_cooptimize_pv_battery.py for the full note
+        # (2026-07-07 refinement).
+        incentive_scenario = IncentiveScenario(cfg.incentive)
         Step9bCoopt.process(
             base_input_dir=base_dir,
             base_output_dir=base_dir,
@@ -51,6 +60,8 @@ def run(cfg: Config) -> None:
             allow_grid_charging=False,
             allow_batt_export=True,
             discount_rate=cfg.discount_rate,
+            pv_capex_per_kw=SolarSystemAppliance.per_kw_cost_net(incentive_scenario),
+            batt_capex_per_kwh=BatteryStorageAppliance.per_kwh_cost_net(incentive_scenario),
         )
     else:
         Step9MyOwnSolarStorage.process(

--- a/pipeline/steps/step14_build_capital_costs_lifetimes_incentives.py
+++ b/pipeline/steps/step14_build_capital_costs_lifetimes_incentives.py
@@ -310,12 +310,13 @@ def build_pv_storage_adjustments_df(
     # Pre-create one battery unit to derive per‑kWh economics
     bat_unit = BatteryStorageAppliance(num_units=1, lifetime_years=15)
     unit_kwh = float(getattr(bat_unit, 'capacity_kwh', 12.5) or 12.5)
-    unit_capex = float(bat_unit.base_cost)
     unit_net_full = float(bat_unit.get_net_cost(IncentiveScenario.FULL_INCENTIVES))
     unit_net_half = float(bat_unit.get_net_cost(IncentiveScenario.HALF_INCENTIVES))
     unit_net_none = float(bat_unit.get_net_cost(IncentiveScenario.NO_INCENTIVES))
 
-    per_kwh_capex = unit_capex / unit_kwh if unit_kwh > 0 else 0.0
+    # Same rate the LP's sizing objective uses (BatteryStorageAppliance.per_kwh_cost) —
+    # sizing and reporting must agree on this number, not derive it independently.
+    per_kwh_capex = BatteryStorageAppliance.per_kwh_cost()
     per_kwh_net_full = unit_net_full / unit_kwh if unit_kwh > 0 else 0.0
     per_kwh_net_half = unit_net_half / unit_kwh if unit_kwh > 0 else 0.0
     per_kwh_net_none = unit_net_none / unit_kwh if unit_kwh > 0 else 0.0

--- a/pipeline/steps/step9b_cooptimize_core.py
+++ b/pipeline/steps/step9b_cooptimize_core.py
@@ -8,6 +8,24 @@ import pandas as pd
 
 from evaluations.eac import crf as _crf, alpha_batt_npv as _alpha_batt_npv
 from evaluations.constants import DEFAULT_DISCOUNT_RATE
+from appliances.solar_system import SolarSystemAppliance
+from appliances.battery_storage import BatteryStorageAppliance
+from appliances.electric_base import IncentiveScenario
+
+# See step9b_cooptimize_pv_battery.py for the full note on why these must
+# match the appliance classes step14 uses for reporting, not a standalone
+# guess — a caller that sizes here without reconciling would repeat the bug
+# found 2026-07-06.
+#
+# Net (not gross) of full_incentives: 2026-07-07 — the LP's sizing decision
+# should reflect what the modeled decision-maker actually pays. Config's
+# default incentive scenario is full_incentives, so a caller that sizes here
+# without an explicit override should assume the same. Real production runs
+# (mod_solar_storage.run) pass the net cost under whichever incentive
+# scenario Config actually specifies, not this static default — see that
+# module for why.
+_DEFAULT_PV_CAPEX_PER_KW = SolarSystemAppliance.per_kw_cost_net(IncentiveScenario.FULL_INCENTIVES)
+_DEFAULT_BATT_CAPEX_PER_KWH = BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.FULL_INCENTIVES)
 
 try:
     import pulp
@@ -227,8 +245,8 @@ def _solve_lp(
     cycle_monthly: bool = False,
     allow_grid_charging: bool = False,
     allow_batt_export: bool = True,
-    c_pv_kw: float = 2830.0,           # $/kW
-    c_batt_kwh: float = 800.0,         # $/kWh (approx, configurable)
+    c_pv_kw: float = _DEFAULT_PV_CAPEX_PER_KW,   # $/kW — see appliances.solar_system, configurable
+    c_batt_kwh: float = _DEFAULT_BATT_CAPEX_PER_KWH,  # $/kWh — see appliances.battery_storage, configurable
     c_batt_kw: float = 0.0,            # $/kW PCS/inverter (optional)
     pv_life_yrs: int = 25,
     batt_life_yrs: int = 15,

--- a/pipeline/steps/step9b_cooptimize_pv_battery.py
+++ b/pipeline/steps/step9b_cooptimize_pv_battery.py
@@ -49,9 +49,9 @@ Flags / configuration
   Enable Grid→Battery charging (off by default)
 - --allow-batt-export / --disallow-batt-export
   Enable or disable Battery→Grid exports (default: enabled)
-- --discount-rate (default: 0.07)
-- --pv-capex-kw (default: 2830.0 $/kW)
-- --batt-capex-kwh (default: 800.0 $/kWh)
+- --discount-rate (default: DEFAULT_DISCOUNT_RATE, evaluations/constants.py)
+- --pv-capex-kw (default: SolarSystemAppliance.per_kw_cost_net(FULL_INCENTIVES), $2,310/kW)
+- --batt-capex-kwh (default: BatteryStorageAppliance.per_kwh_cost_net(FULL_INCENTIVES), ~$1,022/kWh)
 - --batt-capex-kw (default: 0.0 $/kW)
 - --pv-life-yrs (default: 25)
 - --batt-life-yrs (default: 15)
@@ -93,6 +93,29 @@ from .step9b_cooptimize_core import (
     _timestamp_index_8760,
 )
 from evaluations.constants import DEFAULT_DISCOUNT_RATE
+from appliances.solar_system import SolarSystemAppliance
+from appliances.battery_storage import BatteryStorageAppliance
+from appliances.electric_base import IncentiveScenario
+
+# Net (after-incentive, full_incentives scenario) $/kW and $/kWh, derived from
+# the same appliance classes step14 uses to report capex. The LP's sizing
+# objective must use a price consistent with what's actually reported for the
+# scenario being modeled:
+#   - Bug found 2026-07-06: the LP sized against stale hardcoded defaults
+#     ($2,830/kW, $800/kWh) while step14 reported capex at the appliance
+#     classes' real gross values (~$3,300/kW, ~$1,461/kWh) — fixed by
+#     reconciling to the same appliance classes.
+#   - Refinement 2026-07-07: reconciling to *gross* cost left a second,
+#     smaller inconsistency — the paper's default/headline scenario reports
+#     capex net of the 30% ITC (full_incentives), so a decision-maker sizing
+#     against gross cost is using a price ~45% higher than what they'd
+#     actually pay. The LP's sizing signal should match whichever incentive
+#     scenario is actually being reported. These defaults (used when a caller
+#     doesn't specify otherwise) assume full_incentives, matching Config's
+#     own default; real production runs (mod_solar_storage.run) pass the net
+#     cost for whichever incentive scenario Config actually specifies.
+DEFAULT_PV_CAPEX_PER_KW = SolarSystemAppliance.per_kw_cost_net(IncentiveScenario.FULL_INCENTIVES)
+DEFAULT_BATT_CAPEX_PER_KWH = BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.FULL_INCENTIVES)
 
 
 RATE_PLANS = {
@@ -950,8 +973,8 @@ def process(
     pv_capex_sweep: Optional[List[float]] = None,
     coarse_sweeps: bool = False,
     discount_rate: float = DEFAULT_DISCOUNT_RATE,
-    pv_capex_per_kw: float = 2830.0,
-    batt_capex_per_kwh: float = 800.0,
+    pv_capex_per_kw: float = DEFAULT_PV_CAPEX_PER_KW,
+    batt_capex_per_kwh: float = DEFAULT_BATT_CAPEX_PER_KWH,
     batt_capex_per_kw: float = 0.0,
     pv_life_yrs: int = 25,
     batt_life_yrs: int = 15,
@@ -1286,9 +1309,9 @@ def main():
                         "DEFAULT_BATT_SIZE_SWEEP, DEFAULT_PV_SIZE_SWEEP)")
     p.add_argument("--coarse-sweeps", action="store_true",
                    help="Use 12×24 monthly-hourly averages for sweep plots (faster)")
-    p.add_argument("--discount-rate", type=float, default=0.07)
-    p.add_argument("--pv-capex-kw", type=float, default=2830.0)
-    p.add_argument("--batt-capex-kwh", type=float, default=800.0)
+    p.add_argument("--discount-rate", type=float, default=DEFAULT_DISCOUNT_RATE)
+    p.add_argument("--pv-capex-kw", type=float, default=DEFAULT_PV_CAPEX_PER_KW)
+    p.add_argument("--batt-capex-kwh", type=float, default=DEFAULT_BATT_CAPEX_PER_KWH)
     args = p.parse_args()
 
     sweep_vals = list(DEFAULT_BATT_CAPEX_SWEEP) if args.use_defaults else None

--- a/tests/capital_costs_test.py
+++ b/tests/capital_costs_test.py
@@ -1,315 +1,269 @@
 """Capital cost sanity checks against published market prices and research estimates.
 
-Tests verify that the equipment cost assumptions in the pipeline are within
-real-world installed cost ranges. These are not regression tests — they compare
-against independently published price data from LBNL, NREL, and DOE so that
-model assumptions remain grounded in market reality.
+These tests validate the values production code actually uses — the appliance
+classes in appliances/ — not the data/loadprofiles/CAPITAL_COST_DEFINITIONS/
+CSV, which despite looking like documentation is never read by any
+production code path (confirmed 2026-07-06: no import references it anywhere).
+Testing that file gave false confidence — solar, battery, heat pump, and
+induction stove numbers it validated were not the numbers used to build the
+paper's results.
 
 Sources:
-  LBNL Tracking the Sun 2023:
-    CA residential solar installed cost: median $3.9/W-DC; range $2.5–$5.5/W-DC.
-    https://emp.lbl.gov/tracking-the-sun
+  LBNL Tracking the Sun 2023 (cited in CPUC's solar cost report, see below):
+    CA residential solar installed cost: ~$3.80/W-DC (2019 estimate, judged
+    too high by CPUC's own analysis).
 
-  NREL Annual Technology Baseline (ATB) 2024:
-    Residential battery storage: $800–$1,500/kWh installed (includes inverter, BOS).
-    https://atb.nrel.gov/electricity/2024/residential_battery_storage
+  CPUC, "adopted 2023 cost of solar in California"
+    (docs.cpuc.ca.gov/PublishedDocs/Published/G000/M499/K921/499921246.PDF):
+    $3.30/W-DC, reconciling NREL ATB ($2.34/W, judged too low) against LBNL
+    Tracking the Sun ($3.80/W, judged too high); accounts for panel upgrades,
+    delays, and inflation. This is the rate appliances/solar_system.py uses.
 
-  DOE Building Technologies Office / NEEP Cold Climate Heat Pump report (2022):
-    Whole-home air source heat pump (ASHP): $4,000–$20,000 installed.
-    Heat pump water heater (HPWH): $1,000–$5,000 installed.
-    https://neep.org/initiatives/high-efficiency-products/ashp
+  NREL Annual Technology Baseline (ATB) 2024, moderate scenario, via CEC
+    report CEC-200-2024-011 (energy.ca.gov/sites/default/files/2024-07/CEC-200-2024-011.pdf):
+    Residential 5kW/12.5kWh battery system: $18,258 installed (2023 value).
+    This is the rate appliances/battery_storage.py uses.
 
-  DOE / Rewiring America (2022):
-    Induction range/cooktop: $800–$3,500 installed.
-    Gas furnace (baseline replacement): $2,000–$8,000 installed.
-    Gas water heater: $500–$2,500 installed.
-    https://www.rewiringamerica.org/electrification-handbook
+  TECH Clean California program data (CEC), per Simon La Vieille, "EV
+  Integration to Ana's Project" (Aug 2025):
+    Heat pump space heating (ducted systems only, AHRI types without "-O"
+    suffix) and heat pump water heater (Single Family HPWH installs) county
+    median contractor/turnkey costs. Source of data/County_Median_HPSH_Stats.csv
+    and data/County_Median_HPWH_Stats.csv.
 
-  CEC TECH Clean California Initiative (CRIS 2025):
-    Provides California-specific cost data used in the CRIS_2025 methodology rows.
-    https://www.tech-clean-california.com/
+  CARB appliance comparison data ("Cristina's approach"), same report,
+  section "Rest of the Values": induction stove, gas stove, gas water
+  heater, gas heating — each is capital + installation + other (2022),
+  inflated 3.4% CPI-U (BLS) to 2023.
 
-The capital costs CSV contains rows for two methodologies:
-  NEW       — costs from consumer/installer quotes (Tesla, EnergySage, Rewiring America)
-  CRIS_2025 — costs from CARB/CEC TECH California program data
-  BASELINE  — costs for gas appliances retained in baseline scenario
-
-All appliance_id values and their market price bounds are documented per test.
+Because HPSH/HPWH costs are contractor/turnkey (not equipment-only) and
+HPSH is filtered to ducted systems specifically, these run at or above
+generic national ranges (e.g. DOE/NEEP's $4,000-$20,000 ASHP figure, which
+likely includes cheaper ductless mini-splits) — that's an expected
+consequence of the methodology, not a red flag, so bounds here are wider
+than a naive DOE-range check would suggest.
 """
-import glob
 import os
 import sys
 
-import pandas as pd
 import pytest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-CAPITAL_COST_DIR = os.path.join(REPO_ROOT, "data", "loadprofiles", "CAPITAL_COST_DEFINITIONS")
+from appliances.solar_system import SolarSystemAppliance
+from appliances.battery_storage import BatteryStorageAppliance
+from appliances.electric_heating import ElectricHeatingAppliance
+from appliances.electric_water_heating import ElectricWaterHeatingAppliance
+from appliances.electric_cooking import ElectricCookingAppliance
+from appliances.gas_stove import GasStoveAppliance
+from appliances.gas_water_heating import GasWaterHeatingAppliance
+from appliances.gas_heating import GasHeatingAppliance
+from helpers.main_helpers import norcal_counties, central_counties, socal_counties, slugify_county_name
 
 
-def _load_capital_costs() -> pd.DataFrame | None:
-    files = sorted(glob.glob(os.path.join(CAPITAL_COST_DIR, "capital_costs_definitions_*.csv")))
-    if not files:
-        return None
-    df = pd.read_csv(files[-1])
-    df = df.set_index("appliance_id")
-    return df
+PIPELINE_COUNTY_SLUGS = sorted({
+    slugify_county_name(c) for c in norcal_counties + central_counties + socal_counties
+})
 
-
-def _get_cost(df: pd.DataFrame, appliance_id: str) -> float | None:
-    if appliance_id not in df.index:
-        return None
-    return float(df.loc[appliance_id, "cost_per_unit"])
-
-
-# ---------------------------------------------------------------------------
-# Solar panels
-# ---------------------------------------------------------------------------
 
 class TestSolarPanelCost:
-    """Solar panel cost per watt is within the LBNL Tracking the Sun 2023 range.
+    """Solar panel cost per watt matches the CPUC-adopted 2023 CA rate."""
 
-    Source: LBNL Tracking the Sun 2023, California residential systems:
-      Median installed cost: $3.9/W-DC (all-in: hardware + labor + permitting + design).
-      5th–95th percentile range: ~$2.5–$5.5/W-DC.
-      Costs have declined ~50% since 2012, with modest decline continuing.
-      https://emp.lbl.gov/tracking-the-sun
-
-    The model uses $2.80/W-DC (below median, consistent with a competitive quote
-    from a national installer like Tesla or EnergySage marketplace). This is on
-    the lower end of LBNL's range but within the observed market distribution.
-    Values below $2.00/W are no longer realistic for all-in installed cost
-    (even wholesale hardware alone exceeds $0.30/W-DC in 2024).
-    """
-
-    SOLAR_COST_LOWER_PER_W = 2.00   # $/W-DC — below market for all-in installed cost
-    SOLAR_COST_UPPER_PER_W = 6.00   # $/W-DC — above 95th percentile, LBNL 2023
-
-    def test_solar_cost_per_watt_in_market_range(self) -> None:
-        """solar panel installed cost is $2.00–$6.00/W-DC (LBNL Tracking the Sun 2023 range)."""
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found — run step14 or check CAPITAL_COST_DEFINITIONS/.")
-        cost_per_w = _get_cost(df, "solar_panels")
-        if cost_per_w is None:
-            pytest.skip("'solar_panels' not in capital costs — appliance_id may have changed.")
-        assert self.SOLAR_COST_LOWER_PER_W <= cost_per_w <= self.SOLAR_COST_UPPER_PER_W, (
-            f"Solar installed cost: ${cost_per_w:.2f}/W-DC. "
-            f"Expected ${self.SOLAR_COST_LOWER_PER_W}–${self.SOLAR_COST_UPPER_PER_W}/W-DC. "
-            f"LBNL Tracking the Sun 2023: CA median $3.9/W-DC, range $2.5–$5.5/W-DC. "
-            f"Below ${self.SOLAR_COST_LOWER_PER_W}/W: unrealistically cheap for all-in cost. "
-            f"Above ${self.SOLAR_COST_UPPER_PER_W}/W: above 95th percentile — check source."
+    def test_solar_cost_per_kw_matches_cpuc_rate(self) -> None:
+        cost_per_kw = SolarSystemAppliance.per_kw_cost()
+        assert cost_per_kw == pytest.approx(3300.0), (
+            f"Solar installed cost: ${cost_per_kw:,.2f}/kW. Expected $3,300/kW "
+            f"(CPUC-adopted 2023 CA rate, $3.30/W). If this changed intentionally, "
+            f"update this test and docs/methods.yaml together."
         )
 
-
-# ---------------------------------------------------------------------------
-# Battery storage
-# ---------------------------------------------------------------------------
 
 class TestBatteryStorageCost:
-    """Battery storage cost per kWh is within NREL ATB 2024 residential range.
+    """Battery storage cost per kWh matches the NREL ATB 2024 / CEC report rate."""
 
-    Source: NREL Annual Technology Baseline 2024, residential battery storage:
-      Installed cost range: $800–$1,500/kWh (includes inverter, BOS, labor).
-      https://atb.nrel.gov/electricity/2024/residential_battery_storage
-
-    Tesla Powerwall 3 (13.5 kWh usable, 11.5 kW continuous): $11,500 hardware
-    + installation brings all-in cost to ~$13,000–$18,000 → ~$960–$1,330/kWh.
-    The model uses $16,853 total / 13.5 kWh = $1,248/kWh, consistent with
-    premium installation in a high-cost-of-living market.
-    """
-
-    BATTERY_COST_LOWER_PER_KWH = 700    # $/kWh — below NREL lower bound
-    BATTERY_COST_UPPER_PER_KWH = 1_700  # $/kWh — above premium all-in installed cost
-
-    def test_battery_cost_per_kwh_in_market_range(self) -> None:
-        """battery storage installed cost is $700–$1,700/kWh (NREL ATB 2024 residential range)."""
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        if "battery_storage" not in df.index:
-            pytest.skip("'battery_storage' not in capital costs.")
-        row = df.loc["battery_storage"]
-        total_cost = float(row["cost_per_unit"])
-        capacity_kwh = float(row["capacity"]) if pd.notna(row["capacity"]) else None
-        if capacity_kwh is None or capacity_kwh <= 0:
-            pytest.skip("Battery capacity (kWh) not specified in capital costs.")
-        cost_per_kwh = total_cost / capacity_kwh
-        assert self.BATTERY_COST_LOWER_PER_KWH <= cost_per_kwh <= self.BATTERY_COST_UPPER_PER_KWH, (
-            f"Battery installed cost: ${cost_per_kwh:.0f}/kWh "
-            f"(${total_cost:,.0f} total / {capacity_kwh:.1f} kWh usable). "
-            f"Expected ${self.BATTERY_COST_LOWER_PER_KWH:,}–${self.BATTERY_COST_UPPER_PER_KWH:,}/kWh. "
-            f"NREL ATB 2024 residential: $800–$1,500/kWh installed. "
-            f"Tesla Powerwall 3 all-in: ~$960–$1,330/kWh depending on installation."
+    def test_battery_cost_per_kwh_matches_atb_rate(self) -> None:
+        cost_per_kwh = BatteryStorageAppliance.per_kwh_cost()
+        assert cost_per_kwh == pytest.approx(1460.64, rel=1e-3), (
+            f"Battery installed cost: ${cost_per_kwh:,.2f}/kWh "
+            f"(expected $18,258 / 12.5 kWh = $1,460.64/kWh, NREL ATB 2024 moderate "
+            f"scenario via CEC-200-2024-011). If this changed intentionally, "
+            f"update this test and docs/methods.yaml together."
         )
 
+    def test_lp_sizing_price_matches_this_reporting_price(self) -> None:
+        """Regression for the 2026-07-06/07 bugs: the LP must size against the
+        same rate this appliance class reports for the actual scenario being
+        modeled — net of full_incentives (Config's default), not a stale
+        independent default and not the unincentivized gross price."""
+        from appliances.electric_base import IncentiveScenario
+        from pipeline.steps.step9b_cooptimize_core import _DEFAULT_BATT_CAPEX_PER_KWH
+        expected = BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.FULL_INCENTIVES)
+        assert _DEFAULT_BATT_CAPEX_PER_KWH == pytest.approx(expected)
 
-# ---------------------------------------------------------------------------
-# Heat pump: space heating
-# ---------------------------------------------------------------------------
 
 class TestHeatPumpSpaceCost:
-    """Heat pump space heating installed cost is within DOE/NEEP field-study range.
+    """Heat pump space heating cost per county (TECH Clean California, ducted-only).
 
     Source: DOE Building Technologies Office & NEEP cold climate ASHP report (2022):
-      Whole-home air source heat pump installed cost: $4,000–$20,000.
-      Median for a 3-ton system (appropriate for a typical SF home): ~$12,000–$15,000.
-      CEC TECH California CRIS 2025 data: $11,261 for a 3-ton system.
+      Whole-home air source heat pump installed cost: $4,000-$20,000.
       https://neep.org/initiatives/high-efficiency-products/ashp
+    CEC TECH California CRIS 2025 data point: $11,261 for a 3-ton system
+      (see data/loadprofiles/CAPITAL_COST_DEFINITIONS/*.csv, heat_pump_space_cris row —
+      that file isn't read by production code, but this specific figure is a
+      useful independent cross-check).
 
-    The model has two rows for heat pump space heating:
-      heat_pump_space      (NEW methodology): $19,000 — high end but within range
-      heat_pump_space_cris (CRIS_2025):      $11,261 — close to median
-    Both should fall within the documented installed-cost range.
+    This pipeline's actual data is filtered to ducted systems only and reports
+    contractor/turnkey cost (equipment + install) — both push county medians
+    above DOE's range and above the CRIS 3-ton reference point. That's an
+    expected consequence of the documented methodology (see
+    docs/methods.yaml: appliances.electric_heating), not a red flag. The
+    upper bound below is therefore anchored to DOE's ceiling with explicit,
+    documented headroom (2x) rather than either a naive DOE-range check
+    (would false-fail on legitimate data) or an unanchored round number.
     """
 
-    HP_SPACE_LOWER = 3_000    # $ — below minimum realistic installed cost
-    HP_SPACE_UPPER = 25_000   # $ — above documented high end for residential
+    DOE_LOWER = 4_000
+    DOE_UPPER = 20_000
+    CRIS_3_TON_REFERENCE = 11_261
+    LOWER = 3_000              # $ — below DOE's own floor, clearly implausible
+    UPPER = DOE_UPPER * 2      # $ — 2x DOE's ceiling: generous for ducted+turnkey, still catches real corruption
 
-    @pytest.mark.parametrize("appliance_id", ["heat_pump_space", "heat_pump_space_cris"])
-    def test_heat_pump_space_cost_in_range(self, appliance_id: str) -> None:
-        """heat pump space heating installed cost is $3,000–$25,000 (DOE/NEEP 2022 range)."""
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        cost = _get_cost(df, appliance_id)
-        if cost is None:
-            pytest.skip(f"'{appliance_id}' not in capital costs.")
-        assert self.HP_SPACE_LOWER <= cost <= self.HP_SPACE_UPPER, (
-            f"{appliance_id} installed cost: ${cost:,.0f}. "
-            f"Expected ${self.HP_SPACE_LOWER:,}–${self.HP_SPACE_UPPER:,}. "
-            f"DOE/NEEP 2022: whole-home ASHP $4,000–$20,000 installed; "
-            f"CEC TECH CA CRIS 2025: $11,261 (3-ton system)."
-        )
+    def test_all_pipeline_counties_in_plausible_range(self) -> None:
+        for county_slug in PIPELINE_COUNTY_SLUGS:
+            hp = ElectricHeatingAppliance.for_county(county_slug)
+            assert self.LOWER <= hp.base_cost <= self.UPPER, (
+                f"{county_slug}: heat pump space heating cost ${hp.base_cost:,.0f} "
+                f"outside plausible range ${self.LOWER:,}-${self.UPPER:,} "
+                f"(DOE/NEEP 2022 range: ${self.DOE_LOWER:,}-${self.DOE_UPPER:,}; "
+                f"CRIS 2025 3-ton reference: ${self.CRIS_3_TON_REFERENCE:,}). "
+                f"Source: data/County_Median_HPSH_Stats.csv (TECH Clean California, ducted only, turnkey cost)."
+            )
 
+    def test_missing_county_falls_back_to_computed_median_not_a_guess(self) -> None:
+        """Regression: for_county() used to fall back to a hardcoded $19,000 (or
+        an arbitrary first row) for counties absent from the source data. It
+        must compute the actual median of counties present instead."""
+        df = ElectricHeatingAppliance._load_config()
+        expected_median = df[ElectricHeatingAppliance.CAPITAL_COST_COLUMN_NAME].median()
+        missing_county = "not-a-real-county-xyz"
+        assert missing_county not in df.index
+        hp = ElectricHeatingAppliance.for_county(missing_county)
+        assert hp.base_cost == pytest.approx(expected_median)
 
-# ---------------------------------------------------------------------------
-# Heat pump water heater
-# ---------------------------------------------------------------------------
 
 class TestHeatPumpWaterHeaterCost:
-    """Heat pump water heater installed cost is within DOE range.
+    """Heat pump water heater cost per county (TECH Clean California).
 
     Source: DOE Office of Energy Efficiency & Renewable Energy (2023):
-      Heat pump water heater (55-gallon equivalent) installed cost: $1,000–$5,000.
-      Federal tax credit (25C) covers 30% up to $2,000 after 2022.
-      CEC TECH California CRIS 2025: $2,467.
+      Heat pump water heater (55-gallon equivalent) installed cost: $1,000-$5,000.
       https://www.energy.gov/eere/buildings/water-heating
+    CEC TECH California CRIS 2025 data point: $2,467
+      (data/loadprofiles/CAPITAL_COST_DEFINITIONS/*.csv, water_heater_electric_cris row).
 
-    Both NEW and CRIS_2025 methodology rows are checked.
+    Same reasoning as TestHeatPumpSpaceCost: this pipeline's data is
+    contractor/turnkey cost, which runs above DOE's range for a large share
+    of counties (87% exceed $5,000 — verified 2026-07-06). Upper bound is
+    anchored to DOE's ceiling with documented headroom, not unanchored.
     """
 
-    HPWH_LOWER = 1_000   # $
-    HPWH_UPPER = 5_000   # $
+    DOE_LOWER = 1_000
+    DOE_UPPER = 5_000
+    CRIS_REFERENCE = 2_467
+    LOWER = 800                # $ — below plausible even for a bare unit
+    UPPER = DOE_UPPER * 3      # $ — 3x DOE's ceiling: HPWH turnkey costs run further above DOE than HPSH does (worst observed: Lake County ~$14.1k, ~2.8x)
 
-    @pytest.mark.parametrize("appliance_id", ["water_heater_electric", "water_heater_electric_cris"])
-    def test_heat_pump_water_heater_cost_in_range(self, appliance_id: str) -> None:
-        """heat pump water heater installed cost is $1,000–$5,000 (DOE 2023 range)."""
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        cost = _get_cost(df, appliance_id)
-        if cost is None:
-            pytest.skip(f"'{appliance_id}' not in capital costs.")
-        assert self.HPWH_LOWER <= cost <= self.HPWH_UPPER, (
-            f"{appliance_id} installed cost: ${cost:,.0f}. "
-            f"Expected ${self.HPWH_LOWER:,}–${self.HPWH_UPPER:,}. "
-            f"DOE EERE 2023: HPWH installed cost $1,000–$5,000. "
-            f"CEC TECH CA CRIS 2025: $2,467."
-        )
+    def test_all_pipeline_counties_in_plausible_range(self) -> None:
+        for county_slug in PIPELINE_COUNTY_SLUGS:
+            wh = ElectricWaterHeatingAppliance.for_county(county_slug)
+            assert self.LOWER <= wh.base_cost <= self.UPPER, (
+                f"{county_slug}: HPWH cost ${wh.base_cost:,.0f} outside plausible "
+                f"range ${self.LOWER:,}-${self.UPPER:,} "
+                f"(DOE 2023 range: ${self.DOE_LOWER:,}-${self.DOE_UPPER:,}; "
+                f"CRIS 2025 reference: ${self.CRIS_REFERENCE:,}). "
+                f"Source: data/County_Median_HPWH_Stats.csv (TECH Clean California, turnkey cost)."
+            )
+
+    def test_missing_county_falls_back_to_computed_median_not_a_guess(self) -> None:
+        df = ElectricWaterHeatingAppliance._load_config()
+        expected_median = df[ElectricWaterHeatingAppliance.CAPITAL_COST_COLUMN_NAME].median()
+        missing_county = "not-a-real-county-xyz"
+        assert missing_county not in df.index
+        wh = ElectricWaterHeatingAppliance.for_county(missing_county)
+        assert wh.base_cost == pytest.approx(expected_median)
 
 
-# ---------------------------------------------------------------------------
-# Induction stove
-# ---------------------------------------------------------------------------
+class TestCARBAppliancesCost:
+    """Induction stove / gas appliance costs: CARB data + 3.4% CPI-U to 2023.
 
-class TestInductionStoveCost:
-    """Induction stove/range installed cost is within Rewiring America range.
+    Each value is capital + installation + other (2022) * 1.034. See
+    docs/methods.yaml: appliances.carb_appliance_costs for the breakdown.
 
-    Source: Rewiring America Electrification Handbook (2022):
-      Induction range (freestanding) installed cost: $800–$3,500.
-      Mid-range residential models: $1,200–$2,000 (hardware); installation adds $200–$500.
-      https://www.rewiringamerica.org/electrification-handbook
-
-    The model has $2,000 (NEW) and $2,400 (CRIS_2025). Both are in the
-    plausible range for a mid-to-high-quality induction range with installation.
+    Rewiring America Electrification Handbook (2022) cites induction range
+    installed cost as $800-$3,500 (hardware + basic install). CARB's
+    $4,260.08 exceeds that ceiling by ~22% — expected, since it separately
+    itemizes an "other" cost component ($340, e.g. permits/misc) on top of
+    capital + installation, and applies 2023 inflation, both of which
+    Rewiring America's figure may not include.
     """
 
-    INDUCTION_LOWER = 500    # $
-    INDUCTION_UPPER = 4_000  # $
+    REWIRING_AMERICA_LOWER = 800
+    REWIRING_AMERICA_UPPER = 3_500
 
-    @pytest.mark.parametrize("appliance_id", ["induction_stove", "induction_stove_cris"])
-    def test_induction_stove_cost_in_range(self, appliance_id: str) -> None:
-        """induction stove installed cost is $500–$4,000 (Rewiring America 2022 range)."""
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        cost = _get_cost(df, appliance_id)
-        if cost is None:
-            pytest.skip(f"'{appliance_id}' not in capital costs.")
-        assert self.INDUCTION_LOWER <= cost <= self.INDUCTION_UPPER, (
-            f"{appliance_id} installed cost: ${cost:,.0f}. "
-            f"Expected ${self.INDUCTION_LOWER:,}–${self.INDUCTION_UPPER:,}. "
-            f"Rewiring America 2022: induction range $800–$3,500 installed."
+    def test_induction_stove_cost(self) -> None:
+        cost = ElectricCookingAppliance().base_cost
+        assert cost == pytest.approx(4260.08), (
+            f"Induction stove: ${cost:,.2f}, expected $4,260.08. "
+            f"(Rewiring America 2022 range: ${self.REWIRING_AMERICA_LOWER:,}-"
+            f"${self.REWIRING_AMERICA_UPPER:,} — CARB's figure exceeds this by "
+            f"~22%, expected due to its added 'other' cost line + 2023 inflation.)"
         )
 
+    def test_gas_stove_cost(self) -> None:
+        cost = GasStoveAppliance().base_cost
+        assert cost == pytest.approx(2802.14), f"Gas stove: ${cost:,.2f}, expected $2,802.14"
 
-# ---------------------------------------------------------------------------
-# Gas appliances are cheaper than their electric equivalents
-# ---------------------------------------------------------------------------
+    def test_gas_water_heater_cost(self) -> None:
+        cost = GasWaterHeatingAppliance().base_cost
+        assert cost == pytest.approx(2264.46), f"Gas water heater: ${cost:,.2f}, expected $2,264.46"
+
+    def test_gas_heating_cost(self) -> None:
+        cost = GasHeatingAppliance().base_cost
+        assert cost == pytest.approx(9771.30), f"Gas heating: ${cost:,.2f}, expected $9,771.30"
+
 
 class TestGasVsElectricCostOrdering:
     """Gas appliances have lower installed cost than their electric replacements.
 
     This is a key economic assumption in the paper: electrification requires
-    upfront capital for more expensive equipment, and the paper analyzes whether
-    lower operating costs justify the premium.
-
-    If electric appliances are modeled as cheaper than gas, the economic
-    conclusions (payback periods, NPV) will be systematically biased.
-
-    Source: All comparative cost data from DOE EERE, Rewiring America (2022),
-    and CEC TECH California CRIS 2025.
+    upfront capital for more expensive equipment, and the paper analyzes
+    whether lower operating costs justify the premium. If electric appliances
+    were modeled as cheaper than gas, the economic conclusions would be
+    systematically biased.
     """
 
-    def test_heat_pump_space_costs_more_than_gas_furnace(self) -> None:
-        """heat pump space heating costs more to install than a gas furnace.
+    def test_heat_pump_space_costs_more_than_gas_furnace_everywhere(self) -> None:
+        gas_cost = GasHeatingAppliance().base_cost
+        for county_slug in PIPELINE_COUNTY_SLUGS:
+            hp_cost = ElectricHeatingAppliance.for_county(county_slug).base_cost
+            assert hp_cost > gas_cost, (
+                f"{county_slug}: heat pump (${hp_cost:,.0f}) is not more expensive "
+                f"than gas furnace (${gas_cost:,.0f})."
+            )
 
-        DOE: gas furnace $2,000–$8,000; ASHP $4,000–$20,000. The electric
-        alternative should be more expensive upfront, creating a payback story.
-        """
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        hp_cost = _get_cost(df, "heat_pump_space") or _get_cost(df, "heat_pump_space_cris")
-        gas_cost = _get_cost(df, "gas_space_heater")
-        if hp_cost is None or gas_cost is None:
-            pytest.skip("heat pump or gas furnace cost not found in capital costs.")
-        assert hp_cost > gas_cost, (
-            f"Heat pump space (${hp_cost:,.0f}) is not more expensive than "
-            f"gas furnace (${gas_cost:,.0f}). "
-            f"The paper's economic analysis assumes electrification has higher upfront cost. "
-            f"DOE: gas furnace $2,000–$8,000; ASHP $4,000–$20,000."
-        )
+    def test_heat_pump_water_heater_costs_more_than_gas_water_heater_everywhere(self) -> None:
+        gas_cost = GasWaterHeatingAppliance().base_cost
+        for county_slug in PIPELINE_COUNTY_SLUGS:
+            hpwh_cost = ElectricWaterHeatingAppliance.for_county(county_slug).base_cost
+            assert hpwh_cost > gas_cost, (
+                f"{county_slug}: HPWH (${hpwh_cost:,.0f}) is not more expensive "
+                f"than gas water heater (${gas_cost:,.0f})."
+            )
 
-    def test_heat_pump_water_heater_costs_more_than_gas_water_heater(self) -> None:
-        """heat pump water heater costs more to install than a gas water heater.
-
-        DOE: gas water heater $500–$2,500; HPWH $1,000–$5,000. Electric
-        should be more expensive, consistent with the electrification premium story.
-        """
-        df = _load_capital_costs()
-        if df is None:
-            pytest.skip("Capital costs CSV not found.")
-        hpwh_cost = _get_cost(df, "water_heater_electric") or _get_cost(df, "water_heater_electric_cris")
-        gas_wh_cost = _get_cost(df, "gas_water_heater")
-        if hpwh_cost is None or gas_wh_cost is None:
-            pytest.skip("HPWH or gas water heater cost not found in capital costs.")
-        assert hpwh_cost > gas_wh_cost, (
-            f"HPWH (${hpwh_cost:,.0f}) is not more expensive than "
-            f"gas water heater (${gas_wh_cost:,.0f}). "
-            f"DOE: gas water heater $500–$2,500; HPWH $1,000–$5,000."
+    def test_induction_stove_costs_more_than_gas_stove(self) -> None:
+        induction_cost = ElectricCookingAppliance().base_cost
+        gas_cost = GasStoveAppliance().base_cost
+        assert induction_cost > gas_cost, (
+            f"Induction (${induction_cost:,.0f}) is not more expensive than gas (${gas_cost:,.0f})."
         )

--- a/tests/config_plumbing_test.py
+++ b/tests/config_plumbing_test.py
@@ -1,4 +1,4 @@
-"""Regression tests for Config parameters actually reaching the steps that use them.
+git"""Regression tests for Config parameters actually reaching the steps that use them.
 
 Found tonight: `Config.discount_rate` had a correct default and was correctly
 used *inside* step9b's LP and step18's EAC collection — but the module-level
@@ -17,6 +17,8 @@ import inspect
 import os
 import sys
 from unittest.mock import patch
+
+import pytest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
@@ -46,6 +48,39 @@ def test_solar_storage_module_passes_discount_rate_to_lp():
         "otherwise the LP always sizes PV/battery at its own hardcoded default "
         "regardless of what Config specifies."
     )
+
+
+def test_solar_storage_module_sizes_against_net_cost_for_the_configured_incentive_scenario():
+    """2026-07-07 refinement: the LP's sizing price must reflect the actual
+    incentive scenario Config specifies, not always full_incentives. Uses a
+    non-default scenario (no_incentives) specifically so this can't pass by
+    coincidentally matching the common-case default."""
+    import pipeline.modules.solar_storage as mod
+    from appliances.solar_system import SolarSystemAppliance
+    from appliances.battery_storage import BatteryStorageAppliance
+    from appliances.electric_base import IncentiveScenario
+
+    cfg = Config(
+        scenario="baseline_coopt",
+        housing_type="single-family-detached",
+        counties=["Alameda County"],
+        incentive="no_incentives",
+    )
+
+    with patch.object(mod, "WeatherFiles"), patch.object(mod, "Step9bCoopt") as mock_step9b:
+        mod.run(cfg)
+
+    _, kwargs = mock_step9b.process.call_args
+    expected_pv = SolarSystemAppliance.per_kw_cost_net(IncentiveScenario.NO_INCENTIVES)
+    expected_batt = BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.NO_INCENTIVES)
+    assert kwargs.get("pv_capex_per_kw") == pytest.approx(expected_pv), (
+        "mod_solar_storage.run() must size PV against cfg.incentive's net cost, "
+        "not a fixed full_incentives assumption."
+    )
+    assert kwargs.get("batt_capex_per_kwh") == pytest.approx(expected_batt)
+    # no_incentives means net == gross (nothing subtracted)
+    assert expected_pv == pytest.approx(SolarSystemAppliance.per_kw_cost())
+    assert expected_batt == pytest.approx(BatteryStorageAppliance.per_kwh_cost())
 
 
 def test_rates_capital_module_passes_nbc_override_to_step12():

--- a/tests/config_plumbing_test.py
+++ b/tests/config_plumbing_test.py
@@ -1,4 +1,4 @@
-git"""Regression tests for Config parameters actually reaching the steps that use them.
+"""Regression tests for Config parameters actually reaching the steps that use them.
 
 Found tonight: `Config.discount_rate` had a correct default and was correctly
 used *inside* step9b's LP and step18's EAC collection — but the module-level

--- a/tests/lp_cooptimize_test.py
+++ b/tests/lp_cooptimize_test.py
@@ -455,3 +455,70 @@ class TestCapexMatchesEvaluationsPrimitives:
             "the LP must compute its NPV-framing capex coefficients via the shared "
             "primitives, not a local re-derivation."
         )
+
+
+# ---------------------------------------------------------------------------
+# H7 — LP sizing price must match step14's reporting price
+#
+# Bug found 2026-07-06: the LP sized PV/battery against stale hardcoded
+# defaults ($2,830/kW, $800/kWh) while step14 (via SolarSystemAppliance,
+# BatteryStorageAppliance) reported capex for that same system at the real,
+# cited values (~$3,300/kW, ~$1,461/kWh gross). Demonstrated live: a
+# discount-rate sweep at r=0.03 sized a 2.13 kWh battery as "worth it" at
+# $800/kWh, but the reported capex_storage only reconciled at ~$1,023/kWh net
+# of ITC — a price the LP never evaluated the decision against.
+#
+# Refinement 2026-07-07: reconciling to *gross* cost left a second, smaller
+# inconsistency — the paper's default/headline scenario reports capex net of
+# the 30% ITC (full_incentives), not gross. The LP's sizing signal should
+# match whichever incentive scenario is actually reported, so these defaults
+# (assumed when a caller doesn't specify otherwise) are now net of
+# full_incentives, matching Config's own default incentive scenario.
+# ---------------------------------------------------------------------------
+class TestLPSizingPriceMatchesReportingPrice:
+    def test_core_lp_defaults_match_appliance_classes(self):
+        from appliances.electric_base import IncentiveScenario
+        from pipeline.steps.step9b_cooptimize_core import (
+            _DEFAULT_PV_CAPEX_PER_KW,
+            _DEFAULT_BATT_CAPEX_PER_KWH,
+        )
+        from appliances.solar_system import SolarSystemAppliance
+        from appliances.battery_storage import BatteryStorageAppliance
+
+        assert _DEFAULT_PV_CAPEX_PER_KW == pytest.approx(
+            SolarSystemAppliance.per_kw_cost_net(IncentiveScenario.FULL_INCENTIVES)
+        )
+        assert _DEFAULT_BATT_CAPEX_PER_KWH == pytest.approx(
+            BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.FULL_INCENTIVES)
+        )
+
+    def test_process_defaults_match_appliance_classes(self):
+        from appliances.electric_base import IncentiveScenario
+        from pipeline.steps.step9b_cooptimize_pv_battery import (
+            DEFAULT_PV_CAPEX_PER_KW,
+            DEFAULT_BATT_CAPEX_PER_KWH,
+        )
+        from appliances.solar_system import SolarSystemAppliance
+        from appliances.battery_storage import BatteryStorageAppliance
+
+        assert DEFAULT_PV_CAPEX_PER_KW == pytest.approx(
+            SolarSystemAppliance.per_kw_cost_net(IncentiveScenario.FULL_INCENTIVES)
+        )
+        assert DEFAULT_BATT_CAPEX_PER_KWH == pytest.approx(
+            BatteryStorageAppliance.per_kwh_cost_net(IncentiveScenario.FULL_INCENTIVES)
+        )
+
+    def test_lp_default_battery_price_is_not_the_old_stale_value(self):
+        """The old bug's hardcoded $800/kWh was well below the real net
+        reporting price (~$1,022/kWh). Assert the default has actually moved,
+        not just that it's internally self-consistent (which a re-introduced
+        bug could also be, if someone hardcoded the same wrong number in both
+        places)."""
+        from pipeline.steps.step9b_cooptimize_core import _DEFAULT_BATT_CAPEX_PER_KWH
+
+        assert _DEFAULT_BATT_CAPEX_PER_KWH > 950, (
+            f"Default battery $/kWh is {_DEFAULT_BATT_CAPEX_PER_KWH}, suspiciously close to "
+            f"the old stale $800/kWh default. Confirm "
+            f"BatteryStorageAppliance.per_kwh_cost_net(FULL_INCENTIVES) still reflects real "
+            f"market pricing."
+        )


### PR DESCRIPTION
A few changes:
-  capital costs calculation uses BatteryStorageAppliance class
- update steps in pileline to use solar panel and battery constants
- add net-of-incentive cost classmethods to solar and battery appliances
-  size LP against net cost for the actual configured incentive scenario, not gross
- rewrite capital cost tests against real appliance values, restore DOE/CRIS/Rewiring America benchmarks, add incentive-aware sizing tests